### PR TITLE
feat: index export & linting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ target
 **/*.rs.bk
 comptoir/node_modules
 dist/
+js/lib

--- a/js/collection.ts
+++ b/js/collection.ts
@@ -1,402 +1,490 @@
-import * as anchor from '@project-serum/anchor'
-import {Comptoir as ComptoirDefinition, IDL} from './types/comptoir'
-import {COMPTOIR_PROGRAM_ID} from './constant'
-import {Keypair, PublicKey, TransactionInstruction} from '@solana/web3.js'
-import {ASSOCIATED_TOKEN_PROGRAM_ID, TOKEN_PROGRAM_ID} from '@solana/spl-token'
-import {getAssociatedTokenAddress, getBuyOfferPDA, getEscrowPDA, getNftVaultPDA, getSellOrderPDA} from './getPDAs'
-import {getMetadata} from './metaplex'
-import {programs} from '@metaplex/js'
-import * as idl from './types/comptoir.json'
-import {BN, IdlAccounts, web3} from "@project-serum/anchor";
-import {Comptoir} from "./comptoir";
+import * as anchor from '@project-serum/anchor';
+import { Comptoir as ComptoirDefinition, IDL } from './types/comptoir';
+import { COMPTOIR_PROGRAM_ID } from './constant';
+import { Keypair, PublicKey, TransactionInstruction } from '@solana/web3.js';
+import {
+  ASSOCIATED_TOKEN_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
+} from '@solana/spl-token';
+import {
+  getAssociatedTokenAddress,
+  getBuyOfferPDA,
+  getEscrowPDA,
+  getNftVaultPDA,
+  getSellOrderPDA,
+} from './getPDAs';
+import { getMetadata } from './metaplex';
+import { programs } from '@metaplex/js';
+import * as idl from './types/comptoir.json';
+import { BN, IdlAccounts, web3 } from '@project-serum/anchor';
+import { Comptoir } from './comptoir';
+import { MetadataData } from '@metaplex/js/lib/programs/metadata';
 
-const {Metadata} =
-    programs.metadata
+const { Metadata } = programs.metadata;
 
 export class Collection {
-    program: anchor.Program<ComptoirDefinition>
-    collectionPDA: PublicKey
+  program: anchor.Program<ComptoirDefinition>;
+  collectionPDA: PublicKey;
+  comptoir: Comptoir;
+
+  private collectionCache?: IdlAccounts<ComptoirDefinition>['collection'];
+
+  constructor(
+    provider: anchor.Provider,
+    collectionPDA: PublicKey,
     comptoir: Comptoir
+  ) {
+    this.comptoir = comptoir;
+    this.program = new anchor.Program(
+      idl as ComptoirDefinition,
+      COMPTOIR_PROGRAM_ID,
+      provider
+    );
+    this.collectionPDA = collectionPDA;
+  }
 
-    private collectionCache?: IdlAccounts<ComptoirDefinition>["collection"]
-
-    constructor(
-        provider: anchor.Provider,
-        collectionPDA: PublicKey,
-        comptoir: Comptoir,
-    ) {
-        this.comptoir = comptoir
-        // @ts-ignore
-        this.program = new anchor.Program(idl, COMPTOIR_PROGRAM_ID, provider)
-        this.collectionPDA = collectionPDA
+  async sellAssetInstruction(
+    nftMint: PublicKey,
+    sellerNftAccount: PublicKey,
+    sellerDestination: PublicKey,
+    price: anchor.BN,
+    amount: anchor.BN,
+    seller: PublicKey
+  ): Promise<TransactionInstruction> {
+    if (!this.comptoir.comptoirPDA) {
+      throw new Error('comptoirPDA is not set');
     }
 
-    async sellAssetInstruction(
-        nftMint: PublicKey,
-        sellerNftAccount: PublicKey,
-        sellerDestination: PublicKey,
-        price: anchor.BN,
-        amount: anchor.BN,
-        seller: PublicKey,
-    ): Promise<TransactionInstruction> {
-        let programNftVaultPDA = await getNftVaultPDA(nftMint)
-        let sellOrderPDA = await getSellOrderPDA(sellerNftAccount, price)
+    let programNftVaultPDA = await getNftVaultPDA(nftMint);
+    let sellOrderPDA = await getSellOrderPDA(sellerNftAccount, price);
 
-        let metadataPDA = await Metadata.getPDA(nftMint)
-        return await this.program.methods.createSellOrder(price, amount, sellerDestination).accounts(
-            {
-                payer: seller,
-                sellerNftTokenAccount: sellerNftAccount,
-                comptoir: this.comptoir.comptoirPDA,
-                collection: this.collectionPDA,
-                mint: nftMint,
-                metadata: metadataPDA,
-                vault: programNftVaultPDA,
-                sellOrder: sellOrderPDA,
-                systemProgram: anchor.web3.SystemProgram.programId,
-                tokenProgram: TOKEN_PROGRAM_ID,
-                rent: anchor.web3.SYSVAR_RENT_PUBKEY,
-            }
-        ).instruction()
+    let metadataPDA = await Metadata.getPDA(nftMint);
+    return await this.program.methods
+      .createSellOrder(price, amount, sellerDestination)
+      .accounts({
+        payer: seller,
+        sellerNftTokenAccount: sellerNftAccount,
+        comptoir: this.comptoir.comptoirPDA,
+        collection: this.collectionPDA,
+        mint: nftMint,
+        metadata: metadataPDA,
+        vault: programNftVaultPDA,
+        sellOrder: sellOrderPDA,
+        systemProgram: anchor.web3.SystemProgram.programId,
+        tokenProgram: TOKEN_PROGRAM_ID,
+        rent: anchor.web3.SYSVAR_RENT_PUBKEY,
+      })
+      .instruction();
+  }
+
+  async sellAsset(
+    nftMint: PublicKey,
+    sellerNftAccount: PublicKey,
+    sellerDestination: PublicKey,
+    price: anchor.BN,
+    amount: anchor.BN,
+    seller: Keypair
+  ): Promise<string> {
+    let ix = await this.sellAssetInstruction(
+      nftMint,
+      sellerNftAccount,
+      sellerDestination,
+      price,
+      amount,
+      seller.publicKey
+    );
+    return this._sendInstruction(ix, [seller]);
+  }
+
+  async removeSellOrderInstruction(
+    nftMint: PublicKey,
+    sellerNftAccount: PublicKey,
+    sellOrderPDA: PublicKey,
+    amount: anchor.BN,
+    seller: PublicKey
+  ): Promise<TransactionInstruction> {
+    let programNftVaultPDA = await getNftVaultPDA(nftMint);
+    return await this.program.methods
+      .removeSellOrder(amount)
+      .accounts({
+        authority: seller,
+        sellerNftTokenAccount: sellerNftAccount,
+        vault: programNftVaultPDA,
+        sellOrder: sellOrderPDA,
+        systemProgram: anchor.web3.SystemProgram.programId,
+        tokenProgram: TOKEN_PROGRAM_ID,
+        rent: anchor.web3.SYSVAR_RENT_PUBKEY,
+      })
+      .instruction();
+  }
+
+  async removeSellOrder(
+    nftMint: PublicKey,
+    sellerNftAccount: PublicKey,
+    sellOrderPDA: PublicKey,
+    amount: anchor.BN,
+    seller: Keypair
+  ): Promise<string> {
+    let ix = await this.removeSellOrderInstruction(
+      nftMint,
+      sellerNftAccount,
+      sellOrderPDA,
+      amount,
+      seller.publicKey
+    );
+    return this._sendInstruction(ix, [seller]);
+  }
+
+  async addToSellOrderInstruction(
+    nftMint: PublicKey,
+    sellerNftAccount: PublicKey,
+    sellOrderPDA: PublicKey,
+    amount: anchor.BN,
+    seller: PublicKey
+  ): Promise<TransactionInstruction> {
+    let programNftVaultPDA = await getNftVaultPDA(nftMint);
+    return await this.program.methods
+      .addQuantityToSellOrder(amount)
+      .accounts({
+        authority: seller,
+        sellerNftTokenAccount: sellerNftAccount,
+        vault: programNftVaultPDA,
+        sellOrder: sellOrderPDA,
+        systemProgram: anchor.web3.SystemProgram.programId,
+        tokenProgram: TOKEN_PROGRAM_ID,
+        rent: anchor.web3.SYSVAR_RENT_PUBKEY,
+      })
+      .instruction();
+  }
+
+  async addToSellOrder(
+    nftMint: PublicKey,
+    sellerNftAccount: PublicKey,
+    sellOrderPDA: PublicKey,
+    amount: anchor.BN,
+    seller: Keypair
+  ): Promise<string> {
+    let ix = await this.addToSellOrderInstruction(
+      nftMint,
+      sellerNftAccount,
+      sellOrderPDA,
+      amount,
+      seller.publicKey
+    );
+    return this._sendInstruction(ix, [seller]);
+  }
+
+  async buyInstruction(
+    nftMint: PublicKey,
+    sellOrdersPDA: PublicKey[],
+    buyerNftAccount: PublicKey,
+    buyerPayingAccount: PublicKey,
+    wanted_quantity: anchor.BN,
+    buyer: PublicKey
+  ): Promise<TransactionInstruction> {
+    if (!this.comptoir.comptoirPDA) {
+      throw new Error('comptoirPDA is not set');
+    }
+    let comptoirAccount = await this.program.account.comptoir.fetch(
+      this.comptoir.comptoirPDA
+    );
+
+    let metadata = await getMetadata(anchor.getProvider().connection, nftMint);
+
+    let collection = await this.getCollection();
+    let creatorsAccounts: {
+      pubkey: anchor.web3.PublicKey;
+      isWritable: boolean;
+      isSigner: boolean;
+    }[] = [];
+
+    if (!collection.ignoreCreatorFee) {
+      creatorsAccounts = await this._extractCreatorsAsRemainingAccount(
+        metadata
+      );
     }
 
-    async sellAsset(
-        nftMint: PublicKey,
-        sellerNftAccount: PublicKey,
-        sellerDestination: PublicKey,
-        price: anchor.BN,
-        amount: anchor.BN,
-        seller: Keypair
-    ): Promise<string> {
-        let ix = await this.sellAssetInstruction(
-            nftMint, sellerNftAccount, sellerDestination,
-            price, amount, seller.publicKey,
-        )
-        return this._sendInstruction(ix, [seller])
+    let sellOrders = [];
+    for (let sellOrderPDA of sellOrdersPDA) {
+      let so = await this.program.account.sellOrder.fetch(sellOrderPDA);
+      sellOrders.push({
+        pubkey: sellOrderPDA,
+        isWritable: true,
+        isSigner: false,
+      });
+      sellOrders.push({
+        pubkey: so.destination,
+        isWritable: true,
+        isSigner: false,
+      });
     }
 
-    async removeSellOrderInstruction(
-        nftMint: PublicKey,
-        sellerNftAccount: PublicKey,
-        sellOrderPDA: PublicKey,
-        amount: anchor.BN,
-        seller: PublicKey,
-    ): Promise<TransactionInstruction> {
-        let programNftVaultPDA = await getNftVaultPDA(nftMint)
-        return await this.program.methods.removeSellOrder(amount).accounts({
-            authority: seller,
-            sellerNftTokenAccount: sellerNftAccount,
-            vault: programNftVaultPDA,
-            sellOrder: sellOrderPDA,
-            systemProgram: anchor.web3.SystemProgram.programId,
-            tokenProgram: TOKEN_PROGRAM_ID,
-            rent: anchor.web3.SYSVAR_RENT_PUBKEY,
-        }).instruction()
+    let programNftVaultPDA = await getNftVaultPDA(nftMint);
+
+    return await this.program.methods
+      .buy(wanted_quantity)
+      .accounts({
+        buyer: buyer,
+        buyerNftTokenAccount: buyerNftAccount,
+        buyerPayingTokenAccount: buyerPayingAccount,
+        comptoir: this.comptoir.comptoirPDA,
+        comptoirDestAccount: comptoirAccount.feesDestination,
+        collection: this.collectionPDA,
+        metadata: await Metadata.getPDA(metadata.mint),
+        vault: programNftVaultPDA,
+        systemProgram: anchor.web3.SystemProgram.programId,
+        tokenProgram: TOKEN_PROGRAM_ID,
+      })
+      .remainingAccounts([...creatorsAccounts, ...sellOrders])
+      .instruction();
+  }
+
+  async buy(
+    nftMint: PublicKey,
+    sellOrdersPDA: PublicKey[],
+    buyerNftAccount: PublicKey,
+    buyerPayingAccount: PublicKey,
+    wanted_quantity: anchor.BN,
+    buyer: Keypair
+  ): Promise<string> {
+    let ix = await this.buyInstruction(
+      nftMint,
+      sellOrdersPDA,
+      buyerNftAccount,
+      buyerPayingAccount,
+      wanted_quantity,
+      buyer.publicKey
+    );
+    return this._sendInstruction(ix, [buyer]);
+  }
+
+  async createBuyOfferInstruction(
+    nftMintToBuy: PublicKey,
+    offerPrice: anchor.BN,
+    buyerNftAccount: PublicKey,
+    buyerPayingAccount: PublicKey,
+    buyer: PublicKey
+  ): Promise<TransactionInstruction> {
+    if (!this.comptoir.comptoirPDA) {
+      throw new Error('comptoirPDA is not set');
     }
 
-    async removeSellOrder(
-        nftMint: PublicKey,
-        sellerNftAccount: PublicKey,
-        sellOrderPDA: PublicKey,
-        amount: anchor.BN,
-        seller: Keypair,
-    ): Promise<string> {
-        let ix = await this.removeSellOrderInstruction(
-            nftMint,
-            sellerNftAccount,
-            sellOrderPDA,
-            amount,
-            seller.publicKey,
-        )
-        return this._sendInstruction(ix, [seller])
+    let escrowPDA = await getEscrowPDA(
+      this.comptoir.comptoirPDA,
+      (
+        await this.comptoir.getComptoir()
+      ).mint
+    );
+
+    let buyOfferPDA = await getBuyOfferPDA(
+      this.comptoir.comptoirPDA,
+      buyer,
+      nftMintToBuy,
+      offerPrice
+    );
+
+    let metadataPDA = await Metadata.getPDA(nftMintToBuy);
+
+    return await this.program.methods
+      .createBuyOffer(offerPrice)
+      .accounts({
+        payer: buyer,
+        nftMint: nftMintToBuy,
+        metadata: metadataPDA,
+        comptoir: this.comptoir.comptoirPDA,
+        collection: this.collectionPDA,
+        escrow: escrowPDA,
+        buyerNftAccount: buyerNftAccount,
+        buyerPayingAccount: buyerPayingAccount,
+        buyOffer: buyOfferPDA,
+        systemProgram: anchor.web3.SystemProgram.programId,
+        tokenProgram: TOKEN_PROGRAM_ID,
+        associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
+        rent: anchor.web3.SYSVAR_RENT_PUBKEY,
+      })
+      .instruction();
+  }
+
+  async createBuyOffer(
+    nftMintToBuy: PublicKey,
+    offerPrice: anchor.BN,
+    buyerNftAccount: PublicKey,
+    buyerPayingAccount: PublicKey,
+    buyer: Keypair
+  ): Promise<string> {
+    let ix = await this.createBuyOfferInstruction(
+      nftMintToBuy,
+      offerPrice,
+      buyerNftAccount,
+      buyerPayingAccount,
+      buyer.publicKey
+    );
+    return this._sendInstruction(ix, [buyer]);
+  }
+
+  async removeBuyOfferInstruction(
+    nftMintToBuy: PublicKey,
+    buyOfferPDA: PublicKey,
+    buyerTokenAccount: PublicKey,
+    buyer: PublicKey
+  ): Promise<TransactionInstruction> {
+    if (!this.comptoir.comptoirPDA) {
+      throw new Error('comptoirPDA is not set');
+    }
+    let escrowPDA = await getEscrowPDA(
+      this.comptoir.comptoirPDA,
+      (
+        await this.comptoir.getComptoir()
+      ).mint
+    );
+
+    return await this.program.methods
+      .removeBuyOffer()
+      .accounts({
+        buyer: buyer,
+        buyerPayingAccount: buyerTokenAccount,
+        comptoir: this.comptoir.comptoirPDA,
+        escrow: escrowPDA,
+        buyOffer: buyOfferPDA,
+        systemProgram: anchor.web3.SystemProgram.programId,
+        tokenProgram: TOKEN_PROGRAM_ID,
+        rent: anchor.web3.SYSVAR_RENT_PUBKEY,
+      })
+      .instruction();
+  }
+
+  async removeBuyOffer(
+    nftMintToBuy: PublicKey,
+    buyOfferPDA: PublicKey,
+    buyerTokenAccount: PublicKey,
+    buyer: Keypair
+  ): Promise<string> {
+    let ix = await this.removeBuyOfferInstruction(
+      nftMintToBuy,
+      buyOfferPDA,
+      buyerTokenAccount,
+      buyer.publicKey
+    );
+    return this._sendInstruction(ix, [buyer]);
+  }
+
+  async executeOfferInstruction(
+    nftMint: PublicKey,
+    buyOfferPDA: PublicKey,
+    buyer: PublicKey,
+    buyerNftTokenAccount: PublicKey,
+    sellerTokenAccount: PublicKey,
+    sellerNftTokenAccount: PublicKey,
+    seller: PublicKey
+  ): Promise<TransactionInstruction> {
+    let metadata = await getMetadata(anchor.getProvider().connection, nftMint);
+
+    if (!this.comptoir.comptoirPDA) {
+      throw new Error('comptoirPDA is not set');
     }
 
-    async addToSellOrderInstruction(
-        nftMint: PublicKey,
-        sellerNftAccount: PublicKey,
-        sellOrderPDA: PublicKey,
-        amount: anchor.BN,
-        seller: PublicKey,
-    ): Promise<TransactionInstruction> {
-        let programNftVaultPDA = await getNftVaultPDA(nftMint)
-        return await this.program.methods.addQuantityToSellOrder(amount).accounts({
-            authority: seller,
-            sellerNftTokenAccount: sellerNftAccount,
-            vault: programNftVaultPDA,
-            sellOrder: sellOrderPDA,
-            systemProgram: anchor.web3.SystemProgram.programId,
-            tokenProgram: TOKEN_PROGRAM_ID,
-            rent: anchor.web3.SYSVAR_RENT_PUBKEY,
-        }).instruction()
+    let escrowPDA = await getEscrowPDA(
+      this.comptoir.comptoirPDA,
+      (
+        await this.comptoir.getComptoir()
+      ).mint
+    );
+
+    let creatorsAccounts: {
+      pubkey: anchor.web3.PublicKey;
+      isWritable: boolean;
+      isSigner: boolean;
+    }[] = [];
+    if (!(await this.getCollection()).ignoreCreatorFee) {
+      creatorsAccounts = await this._extractCreatorsAsRemainingAccount(
+        metadata
+      );
     }
 
-    async addToSellOrder(
-        nftMint: PublicKey,
-        sellerNftAccount: PublicKey,
-        sellOrderPDA: PublicKey,
-        amount: anchor.BN,
-        seller: Keypair,
-    ): Promise<string> {
-        let ix = await this.addToSellOrderInstruction(
-            nftMint,
-            sellerNftAccount,
-            sellOrderPDA,
-            amount,
-            seller.publicKey,
-        )
-        return this._sendInstruction(ix, [seller])
+    return await this.program.methods
+      .executeOffer()
+      .accounts({
+        seller: seller,
+        buyer: buyer,
+        comptoir: this.comptoir.comptoirPDA,
+        collection: this.collectionPDA,
+        comptoirDestAccount: (
+          await this.comptoir.getComptoir()
+        ).feesDestination,
+        escrow: escrowPDA,
+        sellerFundsDestAccount: sellerTokenAccount,
+        destination: buyerNftTokenAccount,
+        sellerNftAccount: sellerNftTokenAccount,
+        buyOffer: buyOfferPDA,
+        metadata: await Metadata.getPDA(nftMint),
+        systemProgram: anchor.web3.SystemProgram.programId,
+        tokenProgram: TOKEN_PROGRAM_ID,
+        rent: anchor.web3.SYSVAR_RENT_PUBKEY,
+      })
+      .remainingAccounts([...creatorsAccounts])
+      .instruction();
+  }
+
+  async executeOffer(
+    nftMint: PublicKey,
+    buyOfferPDA: PublicKey,
+    buyer: PublicKey,
+    buyerNftTokenAccount: PublicKey,
+    sellerTokenAccount: PublicKey,
+    sellerNftTokenAccount: PublicKey,
+    seller: Keypair
+  ) {
+    let ix = await this.executeOfferInstruction(
+      nftMint,
+      buyOfferPDA,
+      buyer,
+      buyerNftTokenAccount,
+      sellerTokenAccount,
+      sellerNftTokenAccount,
+      seller.publicKey
+    );
+    return this._sendInstruction(ix, [seller]);
+  }
+
+  async getCollection(): Promise<
+    IdlAccounts<ComptoirDefinition>['collection']
+  > {
+    if (this.collectionCache) {
+      return this.collectionCache;
     }
+    this.collectionCache = await this.program.account.collection.fetch(
+      this.collectionPDA
+    );
+    return this.collectionCache;
+  }
 
-    async buyInstruction(
-        nftMint: PublicKey,
-        sellOrdersPDA: PublicKey[],
-        buyerNftAccount: PublicKey,
-        buyerPayingAccount: PublicKey,
-        wanted_quantity: anchor.BN,
-        buyer: PublicKey,
-    ): Promise<TransactionInstruction> {
-        let programNftVaultPDA = await getNftVaultPDA(nftMint)
-        let comptoirAccount = await this.program.account.comptoir.fetch(this.comptoir.comptoirPDA)
+  _sendInstruction(
+    ix: TransactionInstruction,
+    signers: Keypair[]
+  ): Promise<string> {
+    let tx = new web3.Transaction();
+    tx.add(ix);
+    return this.program.provider.send(tx, signers);
+  }
 
-        let metadata = await getMetadata(
-            anchor.getProvider().connection,
-            nftMint,
-        )
+  async _extractCreatorsAsRemainingAccount(metadata: MetadataData) {
+    let creatorsAccounts = [];
+    if (metadata.data?.creators) {
+      for (let creator of metadata.data.creators) {
+        let creatorAddress = new PublicKey(creator.address);
+        let comptoirMint = (await this.comptoir.getComptoir()).mint;
 
-        let collection = await this.getCollection()
-        let creatorsAccounts = []
-
-        if (!collection.ignoreCreatorFee) {
-            creatorsAccounts = await this._extractCreatorsAsRemainingAccount(metadata)
-        }
-
-        let sellOrders = []
-        for (let sellOrderPDA of sellOrdersPDA) {
-            let so = await this.program.account.sellOrder.fetch(sellOrderPDA)
-            sellOrders.push({pubkey: sellOrderPDA, isWritable: true, isSigner: false})
-            sellOrders.push({pubkey: so.destination, isWritable: true, isSigner: false})
-        }
-
-        return await this.program.methods.buy(wanted_quantity).accounts({
-            buyer: buyer,
-            buyerNftTokenAccount: buyerNftAccount,
-            buyerPayingTokenAccount: buyerPayingAccount,
-            comptoir: this.comptoir.comptoirPDA,
-            comptoirDestAccount: comptoirAccount.feesDestination,
-            collection: this.collectionPDA,
-            metadata: await Metadata.getPDA(metadata.mint),
-            vault: programNftVaultPDA,
-            systemProgram: anchor.web3.SystemProgram.programId,
-            tokenProgram: TOKEN_PROGRAM_ID,
-        }).remainingAccounts([
-            ...creatorsAccounts,
-            ...sellOrders,
-        ]).instruction()
+        let creatorATA = await getAssociatedTokenAddress(
+          creatorAddress,
+          comptoirMint
+        );
+        creatorsAccounts.push({
+          pubkey: creatorATA,
+          isWritable: true,
+          isSigner: false,
+        });
+      }
     }
-
-    async buy(
-        nftMint: PublicKey,
-        sellOrdersPDA: PublicKey[],
-        buyerNftAccount: PublicKey,
-        buyerPayingAccount: PublicKey,
-        wanted_quantity: anchor.BN,
-        buyer: Keypair,
-    ): Promise<string> {
-        let ix = await this.buyInstruction(
-            nftMint,
-            sellOrdersPDA,
-            buyerNftAccount,
-            buyerPayingAccount,
-            wanted_quantity,
-            buyer.publicKey,
-        )
-        return this._sendInstruction(ix, [buyer])
-    }
-
-    async createBuyOfferInstruction(
-        nftMintToBuy: PublicKey,
-        offerPrice: anchor.BN,
-        buyerNftAccount: PublicKey,
-        buyerPayingAccount: PublicKey,
-        buyer: PublicKey,
-    ): Promise<TransactionInstruction> {
-        let metadataPDA = await Metadata.getPDA(nftMintToBuy)
-        let escrowPDA = await getEscrowPDA(
-            this.comptoir.comptoirPDA,
-            (await this.comptoir.getComptoir()).mint
-        )
-
-        let buyOfferPDA = await getBuyOfferPDA(
-            this.comptoir.comptoirPDA,
-            buyer,
-            nftMintToBuy,
-            offerPrice,
-        )
-
-        return await this.program.methods.createBuyOffer(offerPrice).accounts(
-            {
-                payer: buyer,
-                nftMint: nftMintToBuy,
-                metadata: metadataPDA,
-                comptoir: this.comptoir.comptoirPDA,
-                collection: this.collectionPDA,
-                escrow: escrowPDA,
-                buyerNftAccount: buyerNftAccount,
-                buyerPayingAccount: buyerPayingAccount,
-                buyOffer: buyOfferPDA,
-                systemProgram: anchor.web3.SystemProgram.programId,
-                tokenProgram: TOKEN_PROGRAM_ID,
-                associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
-                rent: anchor.web3.SYSVAR_RENT_PUBKEY,
-            }
-        ).instruction()
-    }
-
-    async createBuyOffer(
-        nftMintToBuy: PublicKey,
-        offerPrice: anchor.BN,
-        buyerNftAccount: PublicKey,
-        buyerPayingAccount: PublicKey,
-        buyer: Keypair,
-    ): Promise<string> {
-        let ix = await this.createBuyOfferInstruction(
-            nftMintToBuy,
-            offerPrice,
-            buyerNftAccount,
-            buyerPayingAccount,
-            buyer.publicKey,
-        )
-        return this._sendInstruction(ix, [buyer])
-    }
-
-    async removeBuyOfferInstruction(
-        nftMintToBuy: PublicKey,
-        buyOfferPDA: PublicKey,
-        buyerTokenAccount: PublicKey,
-        buyer: PublicKey,
-    ): Promise<TransactionInstruction> {
-        let escrowPDA = await getEscrowPDA(
-            this.comptoir.comptoirPDA,
-            (await this.comptoir.getComptoir()).mint
-        )
-
-        return await this.program.methods.removeBuyOffer().accounts({
-            buyer: buyer,
-            buyerPayingAccount: buyerTokenAccount,
-            comptoir: this.comptoir.comptoirPDA,
-            escrow: escrowPDA,
-            buyOffer: buyOfferPDA,
-            systemProgram: anchor.web3.SystemProgram.programId,
-            tokenProgram: TOKEN_PROGRAM_ID,
-            rent: anchor.web3.SYSVAR_RENT_PUBKEY,
-        }).instruction()
-    }
-
-    async removeBuyOffer(
-        nftMintToBuy: PublicKey,
-        buyOfferPDA: PublicKey,
-        buyerTokenAccount: PublicKey,
-        buyer: Keypair,
-    ): Promise<string> {
-        let ix = await this.removeBuyOfferInstruction(
-            nftMintToBuy,
-            buyOfferPDA,
-            buyerTokenAccount,
-            buyer.publicKey,
-        )
-        return this._sendInstruction(ix, [buyer])
-    }
-
-    async executeOfferInstruction(
-        nftMint: PublicKey,
-        buyOfferPDA: PublicKey,
-        buyer: PublicKey,
-        buyerNftTokenAccount: PublicKey,
-        sellerTokenAccount: PublicKey,
-        sellerNftTokenAccount: PublicKey,
-        seller: PublicKey,
-    ): Promise<TransactionInstruction> {
-        let metadata = await getMetadata(
-            anchor.getProvider().connection,
-            nftMint,
-        )
-
-        let escrowPDA = await getEscrowPDA(
-            this.comptoir.comptoirPDA,
-            (await this.comptoir.getComptoir()).mint
-        )
-
-        let creatorsAccounts = []
-        if (!(await this.getCollection()).ignoreCreatorFee) {
-            creatorsAccounts = await this._extractCreatorsAsRemainingAccount(metadata)
-        }
-
-        return await this.program.methods.executeOffer().accounts({
-            seller: seller,
-            buyer: buyer,
-            comptoir: this.comptoir.comptoirPDA,
-            collection: this.collectionPDA,
-            comptoirDestAccount: (await this.comptoir.getComptoir()).feesDestination,
-            escrow: escrowPDA,
-            sellerFundsDestAccount: sellerTokenAccount,
-            destination: buyerNftTokenAccount,
-            sellerNftAccount: sellerNftTokenAccount,
-            buyOffer: buyOfferPDA,
-            metadata: await Metadata.getPDA(nftMint),
-            systemProgram: anchor.web3.SystemProgram.programId,
-            tokenProgram: TOKEN_PROGRAM_ID,
-            rent: anchor.web3.SYSVAR_RENT_PUBKEY,
-        }).remainingAccounts([
-            ...creatorsAccounts,
-        ]).instruction()
-    }
-
-    async executeOffer(
-        nftMint: PublicKey,
-        buyOfferPDA: PublicKey,
-        buyer: PublicKey,
-        buyerNftTokenAccount: PublicKey,
-        sellerTokenAccount: PublicKey,
-        sellerNftTokenAccount: PublicKey,
-        seller: Keypair,
-    ) {
-        let ix = await this.executeOfferInstruction(
-            nftMint,
-            buyOfferPDA,
-            buyer,
-            buyerNftTokenAccount,
-            sellerTokenAccount,
-            sellerNftTokenAccount,
-            seller.publicKey,
-        )
-        return this._sendInstruction(ix, [seller])
-    }
-
-    async getCollection(): Promise<IdlAccounts<ComptoirDefinition>["collection"]> {
-        if (this.collectionCache) {
-            return this.collectionCache
-        }
-        this.collectionCache = await this.program.account.collection.fetch(this.collectionPDA)
-        return this.collectionCache
-    }
-
-    _sendInstruction(ix: TransactionInstruction, signers: Keypair[]): Promise<string> {
-        let tx = new web3.Transaction()
-        tx.add(ix)
-        return this.program.provider.send(tx, signers)
-    }
-
-    async _extractCreatorsAsRemainingAccount(metadata) {
-        let creatorsAccounts = []
-        for (let creator of metadata.data.creators) {
-            let creatorAddress = new PublicKey(creator.address)
-            let comptoirMint = (await this.comptoir.getComptoir()).mint
-
-            let creatorATA = await getAssociatedTokenAddress(creatorAddress, comptoirMint)
-            creatorsAccounts.push(
-                {pubkey: creatorATA, isWritable: true, isSigner: false},
-            )
-        }
-        return creatorsAccounts
-    }
+    return creatorsAccounts;
+  }
 }

--- a/js/comptoir.ts
+++ b/js/comptoir.ts
@@ -1,78 +1,96 @@
-import * as anchor from '@project-serum/anchor'
-import {Comptoir as ComptoirDefinition} from './types/comptoir'
-import {COMPTOIR_PROGRAM_ID} from './constant'
-import * as idl from './types/comptoir.json'
+import * as anchor from '@project-serum/anchor';
+import { Comptoir as ComptoirDefinition } from './types/comptoir';
+import { COMPTOIR_PROGRAM_ID } from './constant';
+import * as idl from './types/comptoir.json';
 
-import {Keypair, PublicKey} from '@solana/web3.js'
-import {TOKEN_PROGRAM_ID} from '@solana/spl-token'
-import {getCollectionPDA, getComptoirPDA, getEscrowPDA} from './getPDAs'
-import {IdlAccounts} from "@project-serum/anchor";
+import { Keypair, PublicKey } from '@solana/web3.js';
+import { TOKEN_PROGRAM_ID } from '@solana/spl-token';
+import { getCollectionPDA, getComptoirPDA, getEscrowPDA } from './getPDAs';
+import { IdlAccounts } from '@project-serum/anchor';
 
 export class Comptoir {
-    program: anchor.Program<ComptoirDefinition>
-    comptoirPDA: PublicKey
+  program: anchor.Program<ComptoirDefinition>;
+  comptoirPDA: PublicKey | null;
 
-    private comptoirCache?: IdlAccounts<ComptoirDefinition>["comptoir"]
+  private comptoirCache?: IdlAccounts<ComptoirDefinition>['comptoir'];
 
-    constructor(provider: anchor.Provider, comptoirPDA?: PublicKey) {
-        // @ts-ignore
-        this.program = new anchor.Program(idl, COMPTOIR_PROGRAM_ID, provider,)
-        this.comptoirPDA = comptoirPDA
+  constructor(provider: anchor.Provider, comptoirPDA?: PublicKey) {
+    // @ts-ignore
+    this.program = new anchor.Program(idl, COMPTOIR_PROGRAM_ID, provider);
+    this.comptoirPDA = comptoirPDA ?? null;
+  }
+
+  async createComptoir(
+    owner: Keypair,
+    mint: PublicKey,
+    fees: number,
+    feesDestination: PublicKey
+  ): Promise<string> {
+    let comptoirPDA = await getComptoirPDA(owner.publicKey);
+
+    let escrowPDA = await getEscrowPDA(comptoirPDA, mint);
+
+    this.comptoirPDA = comptoirPDA;
+
+    return await this.program.methods
+      .createComptoir(mint, fees, feesDestination, owner.publicKey)
+      .accounts({
+        payer: owner.publicKey,
+        comptoir: comptoirPDA,
+        mint: mint,
+        escrow: escrowPDA,
+        systemProgram: anchor.web3.SystemProgram.programId,
+        tokenProgram: TOKEN_PROGRAM_ID,
+        rent: anchor.web3.SYSVAR_RENT_PUBKEY,
+      })
+      .signers([owner])
+      .rpc();
+  }
+
+  async createCollection(
+    authority: Keypair,
+    name: string,
+    required_metadata_signer: PublicKey,
+    collection_symbol: string,
+    ignore_creators: boolean,
+    fee?: number
+  ): Promise<string> {
+    if (!this.comptoirPDA) {
+      throw new Error('comptoirPDA is not set');
     }
+    let collectionPDA = await getCollectionPDA(
+      this.comptoirPDA,
+      collection_symbol
+    );
 
-    async createComptoir(
-        owner: Keypair,
-        mint: PublicKey,
-        fees: number,
-        feesDestination: PublicKey,
-    ): Promise<string> {
-        let comptoirPDA = await getComptoirPDA(owner.publicKey)
+    return await this.program.methods
+      .createCollection(
+        collection_symbol,
+        required_metadata_signer,
+        fee ?? 0,
+        ignore_creators
+      )
+      .accounts({
+        authority: authority.publicKey,
+        comptoir: this.comptoirPDA,
+        collection: collectionPDA,
+        systemProgram: anchor.web3.SystemProgram.programId,
+        rent: anchor.web3.SYSVAR_RENT_PUBKEY,
+      })
+      .signers([authority])
+      .rpc();
+  }
 
-        let escrowPDA = await getEscrowPDA(comptoirPDA, mint)
-
-        this.comptoirPDA = comptoirPDA
-
-        return await this.program.methods.createComptoir(mint, fees, feesDestination, owner.publicKey).accounts(
-            {
-                payer: owner.publicKey,
-                comptoir: comptoirPDA,
-                mint: mint,
-                escrow: escrowPDA,
-                systemProgram: anchor.web3.SystemProgram.programId,
-                tokenProgram: TOKEN_PROGRAM_ID,
-                rent: anchor.web3.SYSVAR_RENT_PUBKEY,
-            }
-        ).signers([owner]).rpc()
+  async getComptoir(): Promise<IdlAccounts<ComptoirDefinition>['comptoir']> {
+    if (this.comptoirCache) {
+      return this.comptoirCache;
     }
-
-    async createCollection(
-        authority: Keypair,
-        name: string,
-        required_metadata_signer: PublicKey,
-        collection_symbol: string,
-        ignore_creators: boolean,
-        fee?: number,
-    ): Promise<string> {
-        let collectionPDA = await getCollectionPDA(this.comptoirPDA, collection_symbol)
-        if (!fee) {
-            fee = null
-        }
-
-        return await this.program.methods.createCollection(collection_symbol, required_metadata_signer, fee, ignore_creators).accounts(
-            {
-                authority: authority.publicKey,
-                comptoir: this.comptoirPDA,
-                collection: collectionPDA,
-                systemProgram: anchor.web3.SystemProgram.programId,
-                rent: anchor.web3.SYSVAR_RENT_PUBKEY,
-            }).signers([authority]).rpc()
+    if (!this.comptoirPDA) {
+      throw new Error('comptoirPDA is not set');
     }
-
-    async getComptoir(): Promise<IdlAccounts<ComptoirDefinition>["comptoir"]> {
-        if (this.comptoirCache) {
-            return this.comptoirCache
-        }
-        this.comptoirCache = await this.program.account.comptoir.fetch(this.comptoirPDA)
-        return this.comptoirCache
-    }
+    this.comptoirCache = await this.program.account.comptoir.fetch(
+      this.comptoirPDA
+    );
+    return this.comptoirCache;
+  }
 }

--- a/js/constant.ts
+++ b/js/constant.ts
@@ -1,3 +1,5 @@
-import { PublicKey } from '@solana/web3.js'
+import { PublicKey } from '@solana/web3.js';
 
-export const COMPTOIR_PROGRAM_ID : PublicKey = new PublicKey('FCoMPzD3cihsM7EBSbXtorF2yHL4jJ6vrbWtdVaN7qZc')
+export const COMPTOIR_PROGRAM_ID: PublicKey = new PublicKey(
+  'FCoMPzD3cihsM7EBSbXtorF2yHL4jJ6vrbWtdVaN7qZc'
+);

--- a/js/getPDAs.ts
+++ b/js/getPDAs.ts
@@ -1,79 +1,106 @@
-import * as anchor from '@project-serum/anchor'
-import {COMPTOIR_PROGRAM_ID} from './constant'
-import {PublicKey} from '@solana/web3.js'
-import {ASSOCIATED_TOKEN_PROGRAM_ID, Token, TOKEN_PROGRAM_ID} from '@solana/spl-token'
-
+import * as anchor from '@project-serum/anchor';
+import { COMPTOIR_PROGRAM_ID } from './constant';
+import { PublicKey } from '@solana/web3.js';
+import {
+  ASSOCIATED_TOKEN_PROGRAM_ID,
+  Token,
+  TOKEN_PROGRAM_ID,
+} from '@solana/spl-token';
 
 export const getComptoirPDA = async (owner: PublicKey): Promise<PublicKey> => {
-    return (await anchor.web3.PublicKey.findProgramAddress(
-        [
-            Buffer.from('COMPTOIR'),
-            owner.toBuffer()
-        ],
-        COMPTOIR_PROGRAM_ID,
-    ))[0]
-}
-
-export const getEscrowPDA = async (comptoirPDA: PublicKey, comptoirMint: PublicKey): Promise<PublicKey> => {
-    return (await anchor.web3.PublicKey.findProgramAddress(
-        [
-            Buffer.from('COMPTOIR'),
-            comptoirPDA.toBuffer(),
-            comptoirMint.toBuffer(),
-            Buffer.from('ESCROW'),
-        ],
-        COMPTOIR_PROGRAM_ID,
-    ))[0]
-}
-
-export const getCollectionPDA = async (comptoirPDA: PublicKey, symbol: string): Promise<PublicKey> => {
-    return (await anchor.web3.PublicKey.findProgramAddress(
-        [
-            Buffer.from('COMPTOIR'),
-            Buffer.from(symbol),
-            comptoirPDA.toBuffer(),
-        ],
-        COMPTOIR_PROGRAM_ID,
-    ))[0]
-}
-
-export const getNftVaultPDA = async (nftMint: PublicKey): Promise<PublicKey> => {
-    return (await anchor.web3.PublicKey.findProgramAddress(
-        [Buffer.from('COMPTOIR'), Buffer.from('vault'), nftMint.toBuffer()],
-        COMPTOIR_PROGRAM_ID,
-    ))[0]
-}
-
-export const getSellOrderPDA = async (sellerTokenAccount: PublicKey, price: anchor.BN): Promise<PublicKey> => {
-    return (await anchor.web3.PublicKey.findProgramAddress(
-        [
-            Buffer.from('COMPTOIR'),
-            sellerTokenAccount.toBuffer(),
-            Buffer.from(price.toString())
-        ],
-        COMPTOIR_PROGRAM_ID,
-    ))[0]
-}
-
-export const getAssociatedTokenAddress = async (addr: PublicKey, mint: PublicKey): Promise<PublicKey> => {
-    return await Token.getAssociatedTokenAddress(
-        ASSOCIATED_TOKEN_PROGRAM_ID,
-        TOKEN_PROGRAM_ID,
-        mint,
-        addr,
-        false,
+  return (
+    await anchor.web3.PublicKey.findProgramAddress(
+      [Buffer.from('COMPTOIR'), owner.toBuffer()],
+      COMPTOIR_PROGRAM_ID
     )
-}
-export const getBuyOfferPDA = async (comptoirPDA: PublicKey, buyer: PublicKey, mint: PublicKey, price: anchor.BN): Promise<PublicKey> => {
-    return (await anchor.web3.PublicKey.findProgramAddress(
-        [
-            Buffer.from("COMPTOIR"),
-            comptoirPDA.toBuffer(),
-            buyer.toBuffer(),
-            mint.toBuffer(),
-            Buffer.from(price.toString()),
-            Buffer.from("ESCROW"),
-        ],
-        COMPTOIR_PROGRAM_ID,
-    ))[0]
-}
+  )[0];
+};
+
+export const getEscrowPDA = async (
+  comptoirPDA: PublicKey,
+  comptoirMint: PublicKey
+): Promise<PublicKey> => {
+  return (
+    await anchor.web3.PublicKey.findProgramAddress(
+      [
+        Buffer.from('COMPTOIR'),
+        comptoirPDA.toBuffer(),
+        comptoirMint.toBuffer(),
+        Buffer.from('ESCROW'),
+      ],
+      COMPTOIR_PROGRAM_ID
+    )
+  )[0];
+};
+
+export const getCollectionPDA = async (
+  comptoirPDA: PublicKey,
+  symbol: string
+): Promise<PublicKey> => {
+  return (
+    await anchor.web3.PublicKey.findProgramAddress(
+      [Buffer.from('COMPTOIR'), Buffer.from(symbol), comptoirPDA.toBuffer()],
+      COMPTOIR_PROGRAM_ID
+    )
+  )[0];
+};
+
+export const getNftVaultPDA = async (
+  nftMint: PublicKey
+): Promise<PublicKey> => {
+  return (
+    await anchor.web3.PublicKey.findProgramAddress(
+      [Buffer.from('COMPTOIR'), Buffer.from('vault'), nftMint.toBuffer()],
+      COMPTOIR_PROGRAM_ID
+    )
+  )[0];
+};
+
+export const getSellOrderPDA = async (
+  sellerTokenAccount: PublicKey,
+  price: anchor.BN
+): Promise<PublicKey> => {
+  return (
+    await anchor.web3.PublicKey.findProgramAddress(
+      [
+        Buffer.from('COMPTOIR'),
+        sellerTokenAccount.toBuffer(),
+        Buffer.from(price.toString()),
+      ],
+      COMPTOIR_PROGRAM_ID
+    )
+  )[0];
+};
+
+export const getAssociatedTokenAddress = async (
+  addr: PublicKey,
+  mint: PublicKey
+): Promise<PublicKey> => {
+  return await Token.getAssociatedTokenAddress(
+    ASSOCIATED_TOKEN_PROGRAM_ID,
+    TOKEN_PROGRAM_ID,
+    mint,
+    addr,
+    false
+  );
+};
+export const getBuyOfferPDA = async (
+  comptoirPDA: PublicKey,
+  buyer: PublicKey,
+  mint: PublicKey,
+  price: anchor.BN
+): Promise<PublicKey> => {
+  return (
+    await anchor.web3.PublicKey.findProgramAddress(
+      [
+        Buffer.from('COMPTOIR'),
+        comptoirPDA.toBuffer(),
+        buyer.toBuffer(),
+        mint.toBuffer(),
+        Buffer.from(price.toString()),
+        Buffer.from('ESCROW'),
+      ],
+      COMPTOIR_PROGRAM_ID
+    )
+  )[0];
+};

--- a/js/index.ts
+++ b/js/index.ts
@@ -1,0 +1,4 @@
+export { Comptoir } from './comptoir';
+export { Collection } from './collection';
+export { COMPTOIR_PROGRAM_ID } from './constant';
+export { Comptoir as ComptoirDefinition } from './types/comptoir';

--- a/js/index.ts
+++ b/js/index.ts
@@ -1,4 +1,4 @@
 export { Comptoir } from './comptoir';
 export { Collection } from './collection';
 export { COMPTOIR_PROGRAM_ID } from './constant';
-export { Comptoir as ComptoirDefinition } from './types/comptoir';
+export type { Comptoir as ComptoirDefinition } from './types/comptoir';

--- a/js/metaplex.ts
+++ b/js/metaplex.ts
@@ -1,13 +1,11 @@
-import { Connection, PublicKey } from '@solana/web3.js'
-import { programs } from '@metaplex/js'
-const { Metadata, MetadataData } =
-    programs.metadata
+import { Connection, PublicKey } from '@solana/web3.js';
+import { programs } from '@metaplex/js';
+const { Metadata, MetadataData } = programs.metadata;
 
-export const getMetadata = async (
-    connection: Connection,
-    mint: PublicKey,
-)  => {
-    let metadaPDA = await Metadata.getPDA(mint)
-    const metadataAccount = await connection.getAccountInfo(metadaPDA)
-    return MetadataData.deserialize(metadataAccount.data)
-}
+export const getMetadata = async (connection: Connection, mint: PublicKey) => {
+  let metadaPDA = await Metadata.getPDA(mint);
+  const metadataAccount = await connection.getAccountInfo(metadaPDA);
+  return !metadataAccount
+    ? null
+    : MetadataData.deserialize(metadataAccount.data);
+};

--- a/js/package.json
+++ b/js/package.json
@@ -13,6 +13,11 @@
     "@project-serum/anchor": "^0.23.0",
     "@solana/spl-token": "^0.1.8",
     "@solana/web3.js": "^1.31.0",
-    "typescript": "^4.3.5"
+    "ts-node": "^10.7.0",
+    "typescript": "^4.6.3"
+  },
+  "scripts": {
+    "prepublishOnly": "lint",
+    "lint": "tsc --pretty"
   }
 }

--- a/js/package.json
+++ b/js/package.json
@@ -17,7 +17,7 @@
     "typescript": "^4.6.3"
   },
   "scripts": {
-    "prepublishOnly": "lint",
+    "prepublishOnly": "yarn lint",
     "lint": "tsc --pretty"
   }
 }

--- a/js/tsconfig.cjs.json
+++ b/js/tsconfig.cjs.json
@@ -4,6 +4,6 @@
     "module": "commonjs",
     "target": "es2019",
     "outDir": "dist/cjs/",
-    "rootDir": ".",
+    "rootDir": "."
   }
 }

--- a/js/tsconfig.json
+++ b/js/tsconfig.json
@@ -1,14 +1,14 @@
 {
   "compilerOptions": {
-    "typeRoots": [
-        "node_modules/@types"
-    ],
+    "outDir": "lib",
+    "typeRoots": ["node_modules/@types"],
     "lib": ["es2015"],
     "module": "commonjs",
     "target": "es6",
     "esModuleInterop": true,
     "resolveJsonModule": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "strict": true
   },
   "exclude": ["examples"]
 }

--- a/js/types/comptoir.js
+++ b/js/types/comptoir.js
@@ -2,847 +2,847 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.IDL = void 0;
 exports.IDL = {
-    "version": "0.1.0",
-    "name": "comptoir",
-    "instructions": [
+    version: '0.1.0',
+    name: 'comptoir',
+    instructions: [
         {
-            "name": "createComptoir",
-            "accounts": [
+            name: 'createComptoir',
+            accounts: [
                 {
-                    "name": "payer",
-                    "isMut": true,
-                    "isSigner": true
+                    name: 'payer',
+                    isMut: true,
+                    isSigner: true,
                 },
                 {
-                    "name": "comptoir",
-                    "isMut": true,
-                    "isSigner": false
+                    name: 'comptoir',
+                    isMut: true,
+                    isSigner: false,
                 },
                 {
-                    "name": "mint",
-                    "isMut": false,
-                    "isSigner": false
+                    name: 'mint',
+                    isMut: false,
+                    isSigner: false,
                 },
                 {
-                    "name": "escrow",
-                    "isMut": true,
-                    "isSigner": false
+                    name: 'escrow',
+                    isMut: true,
+                    isSigner: false,
                 },
                 {
-                    "name": "systemProgram",
-                    "isMut": false,
-                    "isSigner": false
+                    name: 'systemProgram',
+                    isMut: false,
+                    isSigner: false,
                 },
                 {
-                    "name": "tokenProgram",
-                    "isMut": false,
-                    "isSigner": false
+                    name: 'tokenProgram',
+                    isMut: false,
+                    isSigner: false,
                 },
                 {
-                    "name": "rent",
-                    "isMut": false,
-                    "isSigner": false
-                }
+                    name: 'rent',
+                    isMut: false,
+                    isSigner: false,
+                },
             ],
-            "args": [
+            args: [
                 {
-                    "name": "mint",
-                    "type": "publicKey"
+                    name: 'mint',
+                    type: 'publicKey',
                 },
                 {
-                    "name": "fees",
-                    "type": "u16"
+                    name: 'fees',
+                    type: 'u16',
                 },
                 {
-                    "name": "feesDestination",
-                    "type": "publicKey"
+                    name: 'feesDestination',
+                    type: 'publicKey',
                 },
                 {
-                    "name": "authority",
-                    "type": "publicKey"
-                }
-            ]
+                    name: 'authority',
+                    type: 'publicKey',
+                },
+            ],
         },
         {
-            "name": "updateComptoir",
-            "accounts": [
+            name: 'updateComptoir',
+            accounts: [
                 {
-                    "name": "authority",
-                    "isMut": false,
-                    "isSigner": true
+                    name: 'authority',
+                    isMut: false,
+                    isSigner: true,
                 },
                 {
-                    "name": "comptoir",
-                    "isMut": true,
-                    "isSigner": false
-                }
+                    name: 'comptoir',
+                    isMut: true,
+                    isSigner: false,
+                },
             ],
-            "args": [
+            args: [
                 {
-                    "name": "optionalFees",
-                    "type": {
-                        "option": "u16"
-                    }
+                    name: 'optionalFees',
+                    type: {
+                        option: 'u16',
+                    },
                 },
                 {
-                    "name": "optionalFeesDestination",
-                    "type": {
-                        "option": "publicKey"
-                    }
+                    name: 'optionalFeesDestination',
+                    type: {
+                        option: 'publicKey',
+                    },
                 },
                 {
-                    "name": "optionalAuthority",
-                    "type": {
-                        "option": "publicKey"
-                    }
-                }
-            ]
+                    name: 'optionalAuthority',
+                    type: {
+                        option: 'publicKey',
+                    },
+                },
+            ],
         },
         {
-            "name": "updateComptoirMint",
-            "accounts": [
+            name: 'updateComptoirMint',
+            accounts: [
                 {
-                    "name": "authority",
-                    "isMut": true,
-                    "isSigner": true
+                    name: 'authority',
+                    isMut: true,
+                    isSigner: true,
                 },
                 {
-                    "name": "comptoir",
-                    "isMut": true,
-                    "isSigner": false
+                    name: 'comptoir',
+                    isMut: true,
+                    isSigner: false,
                 },
                 {
-                    "name": "mint",
-                    "isMut": false,
-                    "isSigner": false
+                    name: 'mint',
+                    isMut: false,
+                    isSigner: false,
                 },
                 {
-                    "name": "escrow",
-                    "isMut": true,
-                    "isSigner": false
+                    name: 'escrow',
+                    isMut: true,
+                    isSigner: false,
                 },
                 {
-                    "name": "systemProgram",
-                    "isMut": false,
-                    "isSigner": false
+                    name: 'systemProgram',
+                    isMut: false,
+                    isSigner: false,
                 },
                 {
-                    "name": "tokenProgram",
-                    "isMut": false,
-                    "isSigner": false
+                    name: 'tokenProgram',
+                    isMut: false,
+                    isSigner: false,
                 },
                 {
-                    "name": "rent",
-                    "isMut": false,
-                    "isSigner": false
-                }
+                    name: 'rent',
+                    isMut: false,
+                    isSigner: false,
+                },
             ],
-            "args": [
+            args: [
                 {
-                    "name": "mint",
-                    "type": "publicKey"
+                    name: 'mint',
+                    type: 'publicKey',
                 },
                 {
-                    "name": "feesDestination",
-                    "type": "publicKey"
-                }
-            ]
+                    name: 'feesDestination',
+                    type: 'publicKey',
+                },
+            ],
         },
         {
-            "name": "createCollection",
-            "accounts": [
+            name: 'createCollection',
+            accounts: [
                 {
-                    "name": "authority",
-                    "isMut": true,
-                    "isSigner": true
+                    name: 'authority',
+                    isMut: true,
+                    isSigner: true,
                 },
                 {
-                    "name": "comptoir",
-                    "isMut": true,
-                    "isSigner": false
+                    name: 'comptoir',
+                    isMut: true,
+                    isSigner: false,
                 },
                 {
-                    "name": "collection",
-                    "isMut": true,
-                    "isSigner": false
+                    name: 'collection',
+                    isMut: true,
+                    isSigner: false,
                 },
                 {
-                    "name": "systemProgram",
-                    "isMut": false,
-                    "isSigner": false
+                    name: 'systemProgram',
+                    isMut: false,
+                    isSigner: false,
                 },
                 {
-                    "name": "rent",
-                    "isMut": false,
-                    "isSigner": false
-                }
+                    name: 'rent',
+                    isMut: false,
+                    isSigner: false,
+                },
             ],
-            "args": [
+            args: [
                 {
-                    "name": "symbol",
-                    "type": "string"
+                    name: 'symbol',
+                    type: 'string',
                 },
                 {
-                    "name": "requiredVerifier",
-                    "type": "publicKey"
+                    name: 'requiredVerifier',
+                    type: 'publicKey',
                 },
                 {
-                    "name": "fee",
-                    "type": {
-                        "option": "u16"
-                    }
+                    name: 'fee',
+                    type: {
+                        option: 'u16',
+                    },
                 },
                 {
-                    "name": "ignoreFee",
-                    "type": "bool"
-                }
-            ]
+                    name: 'ignoreFee',
+                    type: 'bool',
+                },
+            ],
         },
         {
-            "name": "updateCollection",
-            "accounts": [
+            name: 'updateCollection',
+            accounts: [
                 {
-                    "name": "authority",
-                    "isMut": false,
-                    "isSigner": true
+                    name: 'authority',
+                    isMut: false,
+                    isSigner: true,
                 },
                 {
-                    "name": "comptoir",
-                    "isMut": false,
-                    "isSigner": false
+                    name: 'comptoir',
+                    isMut: false,
+                    isSigner: false,
                 },
                 {
-                    "name": "collection",
-                    "isMut": true,
-                    "isSigner": false
-                }
+                    name: 'collection',
+                    isMut: true,
+                    isSigner: false,
+                },
             ],
-            "args": [
+            args: [
                 {
-                    "name": "optionalFee",
-                    "type": {
-                        "option": "u16"
-                    }
+                    name: 'optionalFee',
+                    type: {
+                        option: 'u16',
+                    },
                 },
                 {
-                    "name": "optionalSymbol",
-                    "type": {
-                        "option": "string"
-                    }
+                    name: 'optionalSymbol',
+                    type: {
+                        option: 'string',
+                    },
                 },
                 {
-                    "name": "optionalRequiredVerifier",
-                    "type": {
-                        "option": "publicKey"
-                    }
+                    name: 'optionalRequiredVerifier',
+                    type: {
+                        option: 'publicKey',
+                    },
                 },
                 {
-                    "name": "optionalIgnoreCreatorFee",
-                    "type": {
-                        "option": "bool"
-                    }
-                }
-            ]
+                    name: 'optionalIgnoreCreatorFee',
+                    type: {
+                        option: 'bool',
+                    },
+                },
+            ],
         },
         {
-            "name": "createSellOrder",
-            "accounts": [
+            name: 'createSellOrder',
+            accounts: [
                 {
-                    "name": "payer",
-                    "isMut": true,
-                    "isSigner": true
+                    name: 'payer',
+                    isMut: true,
+                    isSigner: true,
                 },
                 {
-                    "name": "sellerNftTokenAccount",
-                    "isMut": true,
-                    "isSigner": false
+                    name: 'sellerNftTokenAccount',
+                    isMut: true,
+                    isSigner: false,
                 },
                 {
-                    "name": "comptoir",
-                    "isMut": false,
-                    "isSigner": false
+                    name: 'comptoir',
+                    isMut: false,
+                    isSigner: false,
                 },
                 {
-                    "name": "collection",
-                    "isMut": false,
-                    "isSigner": false
+                    name: 'collection',
+                    isMut: false,
+                    isSigner: false,
                 },
                 {
-                    "name": "mint",
-                    "isMut": false,
-                    "isSigner": false
+                    name: 'mint',
+                    isMut: false,
+                    isSigner: false,
                 },
                 {
-                    "name": "metadata",
-                    "isMut": false,
-                    "isSigner": false
+                    name: 'metadata',
+                    isMut: false,
+                    isSigner: false,
                 },
                 {
-                    "name": "vault",
-                    "isMut": true,
-                    "isSigner": false
+                    name: 'vault',
+                    isMut: true,
+                    isSigner: false,
                 },
                 {
-                    "name": "sellOrder",
-                    "isMut": true,
-                    "isSigner": false
+                    name: 'sellOrder',
+                    isMut: true,
+                    isSigner: false,
                 },
                 {
-                    "name": "systemProgram",
-                    "isMut": false,
-                    "isSigner": false
+                    name: 'systemProgram',
+                    isMut: false,
+                    isSigner: false,
                 },
                 {
-                    "name": "tokenProgram",
-                    "isMut": false,
-                    "isSigner": false
+                    name: 'tokenProgram',
+                    isMut: false,
+                    isSigner: false,
                 },
                 {
-                    "name": "rent",
-                    "isMut": false,
-                    "isSigner": false
-                }
+                    name: 'rent',
+                    isMut: false,
+                    isSigner: false,
+                },
             ],
-            "args": [
+            args: [
                 {
-                    "name": "price",
-                    "type": "u64"
+                    name: 'price',
+                    type: 'u64',
                 },
                 {
-                    "name": "quantity",
-                    "type": "u64"
+                    name: 'quantity',
+                    type: 'u64',
                 },
                 {
-                    "name": "destination",
-                    "type": "publicKey"
-                }
-            ]
+                    name: 'destination',
+                    type: 'publicKey',
+                },
+            ],
         },
         {
-            "name": "removeSellOrder",
-            "accounts": [
+            name: 'removeSellOrder',
+            accounts: [
                 {
-                    "name": "authority",
-                    "isMut": true,
-                    "isSigner": true
+                    name: 'authority',
+                    isMut: true,
+                    isSigner: true,
                 },
                 {
-                    "name": "sellerNftTokenAccount",
-                    "isMut": true,
-                    "isSigner": false
+                    name: 'sellerNftTokenAccount',
+                    isMut: true,
+                    isSigner: false,
                 },
                 {
-                    "name": "sellOrder",
-                    "isMut": true,
-                    "isSigner": false
+                    name: 'sellOrder',
+                    isMut: true,
+                    isSigner: false,
                 },
                 {
-                    "name": "vault",
-                    "isMut": true,
-                    "isSigner": false
+                    name: 'vault',
+                    isMut: true,
+                    isSigner: false,
                 },
                 {
-                    "name": "systemProgram",
-                    "isMut": false,
-                    "isSigner": false
+                    name: 'systemProgram',
+                    isMut: false,
+                    isSigner: false,
                 },
                 {
-                    "name": "tokenProgram",
-                    "isMut": false,
-                    "isSigner": false
+                    name: 'tokenProgram',
+                    isMut: false,
+                    isSigner: false,
                 },
                 {
-                    "name": "rent",
-                    "isMut": false,
-                    "isSigner": false
-                }
+                    name: 'rent',
+                    isMut: false,
+                    isSigner: false,
+                },
             ],
-            "args": [
+            args: [
                 {
-                    "name": "quantityToUnlist",
-                    "type": "u64"
-                }
-            ]
+                    name: 'quantityToUnlist',
+                    type: 'u64',
+                },
+            ],
         },
         {
-            "name": "addQuantityToSellOrder",
-            "accounts": [
+            name: 'addQuantityToSellOrder',
+            accounts: [
                 {
-                    "name": "authority",
-                    "isMut": true,
-                    "isSigner": true
+                    name: 'authority',
+                    isMut: true,
+                    isSigner: true,
                 },
                 {
-                    "name": "sellerNftTokenAccount",
-                    "isMut": true,
-                    "isSigner": false
+                    name: 'sellerNftTokenAccount',
+                    isMut: true,
+                    isSigner: false,
                 },
                 {
-                    "name": "sellOrder",
-                    "isMut": true,
-                    "isSigner": false
+                    name: 'sellOrder',
+                    isMut: true,
+                    isSigner: false,
                 },
                 {
-                    "name": "vault",
-                    "isMut": true,
-                    "isSigner": false
+                    name: 'vault',
+                    isMut: true,
+                    isSigner: false,
                 },
                 {
-                    "name": "systemProgram",
-                    "isMut": false,
-                    "isSigner": false
+                    name: 'systemProgram',
+                    isMut: false,
+                    isSigner: false,
                 },
                 {
-                    "name": "tokenProgram",
-                    "isMut": false,
-                    "isSigner": false
+                    name: 'tokenProgram',
+                    isMut: false,
+                    isSigner: false,
                 },
                 {
-                    "name": "rent",
-                    "isMut": false,
-                    "isSigner": false
-                }
+                    name: 'rent',
+                    isMut: false,
+                    isSigner: false,
+                },
             ],
-            "args": [
+            args: [
                 {
-                    "name": "quantityToAdd",
-                    "type": "u64"
-                }
-            ]
+                    name: 'quantityToAdd',
+                    type: 'u64',
+                },
+            ],
         },
         {
-            "name": "buy",
-            "accounts": [
+            name: 'buy',
+            accounts: [
                 {
-                    "name": "buyer",
-                    "isMut": false,
-                    "isSigner": true
+                    name: 'buyer',
+                    isMut: false,
+                    isSigner: true,
                 },
                 {
-                    "name": "buyerNftTokenAccount",
-                    "isMut": true,
-                    "isSigner": false
+                    name: 'buyerNftTokenAccount',
+                    isMut: true,
+                    isSigner: false,
                 },
                 {
-                    "name": "buyerPayingTokenAccount",
-                    "isMut": true,
-                    "isSigner": false
+                    name: 'buyerPayingTokenAccount',
+                    isMut: true,
+                    isSigner: false,
                 },
                 {
-                    "name": "comptoir",
-                    "isMut": false,
-                    "isSigner": false
+                    name: 'comptoir',
+                    isMut: false,
+                    isSigner: false,
                 },
                 {
-                    "name": "comptoirDestAccount",
-                    "isMut": true,
-                    "isSigner": false
+                    name: 'comptoirDestAccount',
+                    isMut: true,
+                    isSigner: false,
                 },
                 {
-                    "name": "collection",
-                    "isMut": false,
-                    "isSigner": false
+                    name: 'collection',
+                    isMut: false,
+                    isSigner: false,
                 },
                 {
-                    "name": "metadata",
-                    "isMut": false,
-                    "isSigner": false
+                    name: 'metadata',
+                    isMut: false,
+                    isSigner: false,
                 },
                 {
-                    "name": "vault",
-                    "isMut": true,
-                    "isSigner": false
+                    name: 'vault',
+                    isMut: true,
+                    isSigner: false,
                 },
                 {
-                    "name": "systemProgram",
-                    "isMut": false,
-                    "isSigner": false
+                    name: 'systemProgram',
+                    isMut: false,
+                    isSigner: false,
                 },
                 {
-                    "name": "tokenProgram",
-                    "isMut": false,
-                    "isSigner": false
-                }
+                    name: 'tokenProgram',
+                    isMut: false,
+                    isSigner: false,
+                },
             ],
-            "args": [
+            args: [
                 {
-                    "name": "askQuantity",
-                    "type": "u64"
-                }
-            ]
+                    name: 'askQuantity',
+                    type: 'u64',
+                },
+            ],
         },
         {
-            "name": "createBuyOffer",
-            "accounts": [
+            name: 'createBuyOffer',
+            accounts: [
                 {
-                    "name": "payer",
-                    "isMut": true,
-                    "isSigner": true
+                    name: 'payer',
+                    isMut: true,
+                    isSigner: true,
                 },
                 {
-                    "name": "nftMint",
-                    "isMut": false,
-                    "isSigner": false
+                    name: 'nftMint',
+                    isMut: false,
+                    isSigner: false,
                 },
                 {
-                    "name": "metadata",
-                    "isMut": false,
-                    "isSigner": false
+                    name: 'metadata',
+                    isMut: false,
+                    isSigner: false,
                 },
                 {
-                    "name": "comptoir",
-                    "isMut": false,
-                    "isSigner": false
+                    name: 'comptoir',
+                    isMut: false,
+                    isSigner: false,
                 },
                 {
-                    "name": "collection",
-                    "isMut": true,
-                    "isSigner": false
+                    name: 'collection',
+                    isMut: true,
+                    isSigner: false,
                 },
                 {
-                    "name": "escrow",
-                    "isMut": true,
-                    "isSigner": false
+                    name: 'escrow',
+                    isMut: true,
+                    isSigner: false,
                 },
                 {
-                    "name": "buyerPayingAccount",
-                    "isMut": true,
-                    "isSigner": false
+                    name: 'buyerPayingAccount',
+                    isMut: true,
+                    isSigner: false,
                 },
                 {
-                    "name": "buyerNftAccount",
-                    "isMut": true,
-                    "isSigner": false
+                    name: 'buyerNftAccount',
+                    isMut: true,
+                    isSigner: false,
                 },
                 {
-                    "name": "buyOffer",
-                    "isMut": true,
-                    "isSigner": false
+                    name: 'buyOffer',
+                    isMut: true,
+                    isSigner: false,
                 },
                 {
-                    "name": "systemProgram",
-                    "isMut": false,
-                    "isSigner": false
+                    name: 'systemProgram',
+                    isMut: false,
+                    isSigner: false,
                 },
                 {
-                    "name": "tokenProgram",
-                    "isMut": false,
-                    "isSigner": false
+                    name: 'tokenProgram',
+                    isMut: false,
+                    isSigner: false,
                 },
                 {
-                    "name": "associatedTokenProgram",
-                    "isMut": false,
-                    "isSigner": false
+                    name: 'associatedTokenProgram',
+                    isMut: false,
+                    isSigner: false,
                 },
                 {
-                    "name": "rent",
-                    "isMut": false,
-                    "isSigner": false
-                }
+                    name: 'rent',
+                    isMut: false,
+                    isSigner: false,
+                },
             ],
-            "args": [
+            args: [
                 {
-                    "name": "priceProposition",
-                    "type": "u64"
-                }
-            ]
+                    name: 'priceProposition',
+                    type: 'u64',
+                },
+            ],
         },
         {
-            "name": "removeBuyOffer",
-            "accounts": [
+            name: 'removeBuyOffer',
+            accounts: [
                 {
-                    "name": "buyer",
-                    "isMut": true,
-                    "isSigner": true
+                    name: 'buyer',
+                    isMut: true,
+                    isSigner: true,
                 },
                 {
-                    "name": "buyerPayingAccount",
-                    "isMut": true,
-                    "isSigner": false
+                    name: 'buyerPayingAccount',
+                    isMut: true,
+                    isSigner: false,
                 },
                 {
-                    "name": "comptoir",
-                    "isMut": false,
-                    "isSigner": false
+                    name: 'comptoir',
+                    isMut: false,
+                    isSigner: false,
                 },
                 {
-                    "name": "escrow",
-                    "isMut": true,
-                    "isSigner": false
+                    name: 'escrow',
+                    isMut: true,
+                    isSigner: false,
                 },
                 {
-                    "name": "buyOffer",
-                    "isMut": true,
-                    "isSigner": false
+                    name: 'buyOffer',
+                    isMut: true,
+                    isSigner: false,
                 },
                 {
-                    "name": "systemProgram",
-                    "isMut": false,
-                    "isSigner": false
+                    name: 'systemProgram',
+                    isMut: false,
+                    isSigner: false,
                 },
                 {
-                    "name": "tokenProgram",
-                    "isMut": false,
-                    "isSigner": false
+                    name: 'tokenProgram',
+                    isMut: false,
+                    isSigner: false,
                 },
                 {
-                    "name": "rent",
-                    "isMut": false,
-                    "isSigner": false
-                }
+                    name: 'rent',
+                    isMut: false,
+                    isSigner: false,
+                },
             ],
-            "args": []
+            args: [],
         },
         {
-            "name": "executeOffer",
-            "accounts": [
+            name: 'executeOffer',
+            accounts: [
                 {
-                    "name": "seller",
-                    "isMut": false,
-                    "isSigner": true
+                    name: 'seller',
+                    isMut: false,
+                    isSigner: true,
                 },
                 {
-                    "name": "buyer",
-                    "isMut": true,
-                    "isSigner": false
+                    name: 'buyer',
+                    isMut: true,
+                    isSigner: false,
                 },
                 {
-                    "name": "comptoir",
-                    "isMut": false,
-                    "isSigner": false
+                    name: 'comptoir',
+                    isMut: false,
+                    isSigner: false,
                 },
                 {
-                    "name": "collection",
-                    "isMut": true,
-                    "isSigner": false
+                    name: 'collection',
+                    isMut: true,
+                    isSigner: false,
                 },
                 {
-                    "name": "comptoirDestAccount",
-                    "isMut": true,
-                    "isSigner": false
+                    name: 'comptoirDestAccount',
+                    isMut: true,
+                    isSigner: false,
                 },
                 {
-                    "name": "escrow",
-                    "isMut": true,
-                    "isSigner": false
+                    name: 'escrow',
+                    isMut: true,
+                    isSigner: false,
                 },
                 {
-                    "name": "sellerFundsDestAccount",
-                    "isMut": true,
-                    "isSigner": false
+                    name: 'sellerFundsDestAccount',
+                    isMut: true,
+                    isSigner: false,
                 },
                 {
-                    "name": "destination",
-                    "isMut": true,
-                    "isSigner": false
+                    name: 'destination',
+                    isMut: true,
+                    isSigner: false,
                 },
                 {
-                    "name": "sellerNftAccount",
-                    "isMut": true,
-                    "isSigner": false
+                    name: 'sellerNftAccount',
+                    isMut: true,
+                    isSigner: false,
                 },
                 {
-                    "name": "metadata",
-                    "isMut": false,
-                    "isSigner": false
+                    name: 'metadata',
+                    isMut: false,
+                    isSigner: false,
                 },
                 {
-                    "name": "buyOffer",
-                    "isMut": true,
-                    "isSigner": false
+                    name: 'buyOffer',
+                    isMut: true,
+                    isSigner: false,
                 },
                 {
-                    "name": "systemProgram",
-                    "isMut": false,
-                    "isSigner": false
+                    name: 'systemProgram',
+                    isMut: false,
+                    isSigner: false,
                 },
                 {
-                    "name": "tokenProgram",
-                    "isMut": false,
-                    "isSigner": false
+                    name: 'tokenProgram',
+                    isMut: false,
+                    isSigner: false,
                 },
                 {
-                    "name": "rent",
-                    "isMut": false,
-                    "isSigner": false
-                }
+                    name: 'rent',
+                    isMut: false,
+                    isSigner: false,
+                },
             ],
-            "args": []
-        }
+            args: [],
+        },
     ],
-    "accounts": [
+    accounts: [
         {
-            "name": "comptoir",
-            "type": {
-                "kind": "struct",
-                "fields": [
+            name: 'comptoir',
+            type: {
+                kind: 'struct',
+                fields: [
                     {
-                        "name": "fees",
-                        "type": "u16"
+                        name: 'fees',
+                        type: 'u16',
                     },
                     {
-                        "name": "feesDestination",
-                        "type": "publicKey"
+                        name: 'feesDestination',
+                        type: 'publicKey',
                     },
                     {
-                        "name": "authority",
-                        "type": "publicKey"
+                        name: 'authority',
+                        type: 'publicKey',
                     },
                     {
-                        "name": "mint",
-                        "type": "publicKey"
-                    }
-                ]
-            }
+                        name: 'mint',
+                        type: 'publicKey',
+                    },
+                ],
+            },
         },
         {
-            "name": "sellOrder",
-            "type": {
-                "kind": "struct",
-                "fields": [
+            name: 'sellOrder',
+            type: {
+                kind: 'struct',
+                fields: [
                     {
-                        "name": "comptoir",
-                        "type": "publicKey"
+                        name: 'comptoir',
+                        type: 'publicKey',
                     },
                     {
-                        "name": "price",
-                        "type": "u64"
+                        name: 'price',
+                        type: 'u64',
                     },
                     {
-                        "name": "quantity",
-                        "type": "u64"
+                        name: 'quantity',
+                        type: 'u64',
                     },
                     {
-                        "name": "mint",
-                        "type": "publicKey"
+                        name: 'mint',
+                        type: 'publicKey',
                     },
                     {
-                        "name": "authority",
-                        "type": "publicKey"
+                        name: 'authority',
+                        type: 'publicKey',
                     },
                     {
-                        "name": "destination",
-                        "type": "publicKey"
-                    }
-                ]
-            }
+                        name: 'destination',
+                        type: 'publicKey',
+                    },
+                ],
+            },
         },
         {
-            "name": "collection",
-            "type": {
-                "kind": "struct",
-                "fields": [
+            name: 'collection',
+            type: {
+                kind: 'struct',
+                fields: [
                     {
-                        "name": "comptoirKey",
-                        "type": "publicKey"
+                        name: 'comptoirKey',
+                        type: 'publicKey',
                     },
                     {
-                        "name": "symbol",
-                        "type": "string"
+                        name: 'symbol',
+                        type: 'string',
                     },
                     {
-                        "name": "requiredVerifier",
-                        "type": "publicKey"
+                        name: 'requiredVerifier',
+                        type: 'publicKey',
                     },
                     {
-                        "name": "fees",
-                        "type": {
-                            "option": "u16"
-                        }
+                        name: 'fees',
+                        type: {
+                            option: 'u16',
+                        },
                     },
                     {
-                        "name": "ignoreCreatorFee",
-                        "type": "bool"
-                    }
-                ]
-            }
+                        name: 'ignoreCreatorFee',
+                        type: 'bool',
+                    },
+                ],
+            },
         },
         {
-            "name": "buyOffer",
-            "type": {
-                "kind": "struct",
-                "fields": [
+            name: 'buyOffer',
+            type: {
+                kind: 'struct',
+                fields: [
                     {
-                        "name": "comptoir",
-                        "type": "publicKey"
+                        name: 'comptoir',
+                        type: 'publicKey',
                     },
                     {
-                        "name": "mint",
-                        "type": "publicKey"
+                        name: 'mint',
+                        type: 'publicKey',
                     },
                     {
-                        "name": "proposedPrice",
-                        "type": "u64"
+                        name: 'proposedPrice',
+                        type: 'u64',
                     },
                     {
-                        "name": "authority",
-                        "type": "publicKey"
+                        name: 'authority',
+                        type: 'publicKey',
                     },
                     {
-                        "name": "destination",
-                        "type": "publicKey"
-                    }
-                ]
-            }
-        }
+                        name: 'destination',
+                        type: 'publicKey',
+                    },
+                ],
+            },
+        },
     ],
-    "events": [
+    events: [
         {
-            "name": "BoughtSellOrderEvent",
-            "fields": [
+            name: 'BoughtSellOrderEvent',
+            fields: [
                 {
-                    "name": "sellOrder",
-                    "type": "publicKey",
-                    "index": false
+                    name: 'sellOrder',
+                    type: 'publicKey',
+                    index: false,
                 },
                 {
-                    "name": "quantity",
-                    "type": "u64",
-                    "index": false
+                    name: 'quantity',
+                    type: 'u64',
+                    index: false,
                 },
                 {
-                    "name": "buyer",
-                    "type": "publicKey",
-                    "index": false
-                }
-            ]
-        }
+                    name: 'buyer',
+                    type: 'publicKey',
+                    index: false,
+                },
+            ],
+        },
     ],
-    "errors": [
+    errors: [
         {
-            "code": 6000,
-            "name": "ErrFeeShouldLowerOrEqualThan10000",
-            "msg": "Fee should be <= 10000"
+            code: 6000,
+            name: 'ErrFeeShouldLowerOrEqualThan10000',
+            msg: 'Fee should be <= 10000',
         },
         {
-            "code": 6001,
-            "name": "ErrTryingToUnlistMoreThanOwned",
-            "msg": "Trying to unlist more than owned"
+            code: 6001,
+            name: 'ErrTryingToUnlistMoreThanOwned',
+            msg: 'Trying to unlist more than owned',
         },
         {
-            "code": 6002,
-            "name": "ErrCouldNotBuyEnoughItem",
-            "msg": "Could not buy the required quantity of items"
+            code: 6002,
+            name: 'ErrCouldNotBuyEnoughItem',
+            msg: 'Could not buy the required quantity of items',
         },
         {
-            "code": 6003,
-            "name": "ErrMetaDataMintDoesNotMatchItemMint",
-            "msg": "metadata mint does not match item mint"
+            code: 6003,
+            name: 'ErrMetaDataMintDoesNotMatchItemMint',
+            msg: 'metadata mint does not match item mint',
         },
         {
-            "code": 6004,
-            "name": "ErrNftNotPartOfCollection",
-            "msg": "nft not part of collection"
+            code: 6004,
+            name: 'ErrNftNotPartOfCollection',
+            msg: 'nft not part of collection',
         },
         {
-            "code": 6005,
-            "name": "DerivedKeyInvalid",
-            "msg": "Derived key invalid"
+            code: 6005,
+            name: 'DerivedKeyInvalid',
+            msg: 'Derived key invalid',
         },
         {
-            "code": 6006,
-            "name": "NotInitialized",
-            "msg": "AccountNotInitialized"
-        }
-    ]
+            code: 6006,
+            name: 'NotInitialized',
+            msg: 'AccountNotInitialized',
+        },
+    ],
 };

--- a/js/types/comptoir.ts
+++ b/js/types/comptoir.ts
@@ -1,1691 +1,1691 @@
 export type Comptoir = {
-  "version": "0.1.0",
-  "name": "comptoir",
-  "instructions": [
+  version: '0.1.0';
+  name: 'comptoir';
+  instructions: [
     {
-      "name": "createComptoir",
-      "accounts": [
+      name: 'createComptoir';
+      accounts: [
         {
-          "name": "payer",
-          "isMut": true,
-          "isSigner": true
+          name: 'payer';
+          isMut: true;
+          isSigner: true;
         },
         {
-          "name": "comptoir",
-          "isMut": true,
-          "isSigner": false
+          name: 'comptoir';
+          isMut: true;
+          isSigner: false;
         },
         {
-          "name": "mint",
-          "isMut": false,
-          "isSigner": false
+          name: 'mint';
+          isMut: false;
+          isSigner: false;
         },
         {
-          "name": "escrow",
-          "isMut": true,
-          "isSigner": false
+          name: 'escrow';
+          isMut: true;
+          isSigner: false;
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
+          name: 'systemProgram';
+          isMut: false;
+          isSigner: false;
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
+          name: 'tokenProgram';
+          isMut: false;
+          isSigner: false;
         },
         {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
+          name: 'rent';
+          isMut: false;
+          isSigner: false;
         }
-      ],
-      "args": [
+      ];
+      args: [
         {
-          "name": "mint",
-          "type": "publicKey"
+          name: 'mint';
+          type: 'publicKey';
         },
         {
-          "name": "fees",
-          "type": "u16"
+          name: 'fees';
+          type: 'u16';
         },
         {
-          "name": "feesDestination",
-          "type": "publicKey"
+          name: 'feesDestination';
+          type: 'publicKey';
         },
         {
-          "name": "authority",
-          "type": "publicKey"
+          name: 'authority';
+          type: 'publicKey';
         }
-      ]
+      ];
     },
     {
-      "name": "updateComptoir",
-      "accounts": [
+      name: 'updateComptoir';
+      accounts: [
         {
-          "name": "authority",
-          "isMut": false,
-          "isSigner": true
+          name: 'authority';
+          isMut: false;
+          isSigner: true;
         },
         {
-          "name": "comptoir",
-          "isMut": true,
-          "isSigner": false
+          name: 'comptoir';
+          isMut: true;
+          isSigner: false;
         }
-      ],
-      "args": [
+      ];
+      args: [
         {
-          "name": "optionalFees",
-          "type": {
-            "option": "u16"
-          }
+          name: 'optionalFees';
+          type: {
+            option: 'u16';
+          };
         },
         {
-          "name": "optionalFeesDestination",
-          "type": {
-            "option": "publicKey"
-          }
+          name: 'optionalFeesDestination';
+          type: {
+            option: 'publicKey';
+          };
         },
         {
-          "name": "optionalAuthority",
-          "type": {
-            "option": "publicKey"
-          }
+          name: 'optionalAuthority';
+          type: {
+            option: 'publicKey';
+          };
         }
-      ]
+      ];
     },
     {
-      "name": "updateComptoirMint",
-      "accounts": [
+      name: 'updateComptoirMint';
+      accounts: [
         {
-          "name": "authority",
-          "isMut": true,
-          "isSigner": true
+          name: 'authority';
+          isMut: true;
+          isSigner: true;
         },
         {
-          "name": "comptoir",
-          "isMut": true,
-          "isSigner": false
+          name: 'comptoir';
+          isMut: true;
+          isSigner: false;
         },
         {
-          "name": "mint",
-          "isMut": false,
-          "isSigner": false
+          name: 'mint';
+          isMut: false;
+          isSigner: false;
         },
         {
-          "name": "escrow",
-          "isMut": true,
-          "isSigner": false
+          name: 'escrow';
+          isMut: true;
+          isSigner: false;
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
+          name: 'systemProgram';
+          isMut: false;
+          isSigner: false;
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
+          name: 'tokenProgram';
+          isMut: false;
+          isSigner: false;
         },
         {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
+          name: 'rent';
+          isMut: false;
+          isSigner: false;
         }
-      ],
-      "args": [
+      ];
+      args: [
         {
-          "name": "mint",
-          "type": "publicKey"
+          name: 'mint';
+          type: 'publicKey';
         },
         {
-          "name": "feesDestination",
-          "type": "publicKey"
+          name: 'feesDestination';
+          type: 'publicKey';
         }
-      ]
+      ];
     },
     {
-      "name": "createCollection",
-      "accounts": [
+      name: 'createCollection';
+      accounts: [
         {
-          "name": "authority",
-          "isMut": true,
-          "isSigner": true
+          name: 'authority';
+          isMut: true;
+          isSigner: true;
         },
         {
-          "name": "comptoir",
-          "isMut": true,
-          "isSigner": false
+          name: 'comptoir';
+          isMut: true;
+          isSigner: false;
         },
         {
-          "name": "collection",
-          "isMut": true,
-          "isSigner": false
+          name: 'collection';
+          isMut: true;
+          isSigner: false;
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
+          name: 'systemProgram';
+          isMut: false;
+          isSigner: false;
         },
         {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
+          name: 'rent';
+          isMut: false;
+          isSigner: false;
         }
-      ],
-      "args": [
+      ];
+      args: [
         {
-          "name": "symbol",
-          "type": "string"
+          name: 'symbol';
+          type: 'string';
         },
         {
-          "name": "requiredVerifier",
-          "type": "publicKey"
+          name: 'requiredVerifier';
+          type: 'publicKey';
         },
         {
-          "name": "fee",
-          "type": {
-            "option": "u16"
-          }
+          name: 'fee';
+          type: {
+            option: 'u16';
+          };
         },
         {
-          "name": "ignoreFee",
-          "type": "bool"
+          name: 'ignoreFee';
+          type: 'bool';
         }
-      ]
+      ];
     },
     {
-      "name": "updateCollection",
-      "accounts": [
+      name: 'updateCollection';
+      accounts: [
         {
-          "name": "authority",
-          "isMut": false,
-          "isSigner": true
+          name: 'authority';
+          isMut: false;
+          isSigner: true;
         },
         {
-          "name": "comptoir",
-          "isMut": false,
-          "isSigner": false
+          name: 'comptoir';
+          isMut: false;
+          isSigner: false;
         },
         {
-          "name": "collection",
-          "isMut": true,
-          "isSigner": false
+          name: 'collection';
+          isMut: true;
+          isSigner: false;
         }
-      ],
-      "args": [
+      ];
+      args: [
         {
-          "name": "optionalFee",
-          "type": {
-            "option": "u16"
-          }
+          name: 'optionalFee';
+          type: {
+            option: 'u16';
+          };
         },
         {
-          "name": "optionalSymbol",
-          "type": {
-            "option": "string"
-          }
+          name: 'optionalSymbol';
+          type: {
+            option: 'string';
+          };
         },
         {
-          "name": "optionalRequiredVerifier",
-          "type": {
-            "option": "publicKey"
-          }
+          name: 'optionalRequiredVerifier';
+          type: {
+            option: 'publicKey';
+          };
         },
         {
-          "name": "optionalIgnoreCreatorFee",
-          "type": {
-            "option": "bool"
-          }
+          name: 'optionalIgnoreCreatorFee';
+          type: {
+            option: 'bool';
+          };
         }
-      ]
+      ];
     },
     {
-      "name": "createSellOrder",
-      "accounts": [
+      name: 'createSellOrder';
+      accounts: [
         {
-          "name": "payer",
-          "isMut": true,
-          "isSigner": true
+          name: 'payer';
+          isMut: true;
+          isSigner: true;
         },
         {
-          "name": "sellerNftTokenAccount",
-          "isMut": true,
-          "isSigner": false
+          name: 'sellerNftTokenAccount';
+          isMut: true;
+          isSigner: false;
         },
         {
-          "name": "comptoir",
-          "isMut": false,
-          "isSigner": false
+          name: 'comptoir';
+          isMut: false;
+          isSigner: false;
         },
         {
-          "name": "collection",
-          "isMut": false,
-          "isSigner": false
+          name: 'collection';
+          isMut: false;
+          isSigner: false;
         },
         {
-          "name": "mint",
-          "isMut": false,
-          "isSigner": false
+          name: 'mint';
+          isMut: false;
+          isSigner: false;
         },
         {
-          "name": "metadata",
-          "isMut": false,
-          "isSigner": false
+          name: 'metadata';
+          isMut: false;
+          isSigner: false;
         },
         {
-          "name": "vault",
-          "isMut": true,
-          "isSigner": false
+          name: 'vault';
+          isMut: true;
+          isSigner: false;
         },
         {
-          "name": "sellOrder",
-          "isMut": true,
-          "isSigner": false
+          name: 'sellOrder';
+          isMut: true;
+          isSigner: false;
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
+          name: 'systemProgram';
+          isMut: false;
+          isSigner: false;
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
+          name: 'tokenProgram';
+          isMut: false;
+          isSigner: false;
         },
         {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
+          name: 'rent';
+          isMut: false;
+          isSigner: false;
         }
-      ],
-      "args": [
+      ];
+      args: [
         {
-          "name": "price",
-          "type": "u64"
+          name: 'price';
+          type: 'u64';
         },
         {
-          "name": "quantity",
-          "type": "u64"
+          name: 'quantity';
+          type: 'u64';
         },
         {
-          "name": "destination",
-          "type": "publicKey"
+          name: 'destination';
+          type: 'publicKey';
         }
-      ]
+      ];
     },
     {
-      "name": "removeSellOrder",
-      "accounts": [
+      name: 'removeSellOrder';
+      accounts: [
         {
-          "name": "authority",
-          "isMut": true,
-          "isSigner": true
+          name: 'authority';
+          isMut: true;
+          isSigner: true;
         },
         {
-          "name": "sellerNftTokenAccount",
-          "isMut": true,
-          "isSigner": false
+          name: 'sellerNftTokenAccount';
+          isMut: true;
+          isSigner: false;
         },
         {
-          "name": "sellOrder",
-          "isMut": true,
-          "isSigner": false
+          name: 'sellOrder';
+          isMut: true;
+          isSigner: false;
         },
         {
-          "name": "vault",
-          "isMut": true,
-          "isSigner": false
+          name: 'vault';
+          isMut: true;
+          isSigner: false;
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
+          name: 'systemProgram';
+          isMut: false;
+          isSigner: false;
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
+          name: 'tokenProgram';
+          isMut: false;
+          isSigner: false;
         },
         {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
+          name: 'rent';
+          isMut: false;
+          isSigner: false;
         }
-      ],
-      "args": [
+      ];
+      args: [
         {
-          "name": "quantityToUnlist",
-          "type": "u64"
+          name: 'quantityToUnlist';
+          type: 'u64';
         }
-      ]
+      ];
     },
     {
-      "name": "addQuantityToSellOrder",
-      "accounts": [
+      name: 'addQuantityToSellOrder';
+      accounts: [
         {
-          "name": "authority",
-          "isMut": true,
-          "isSigner": true
+          name: 'authority';
+          isMut: true;
+          isSigner: true;
         },
         {
-          "name": "sellerNftTokenAccount",
-          "isMut": true,
-          "isSigner": false
+          name: 'sellerNftTokenAccount';
+          isMut: true;
+          isSigner: false;
         },
         {
-          "name": "sellOrder",
-          "isMut": true,
-          "isSigner": false
+          name: 'sellOrder';
+          isMut: true;
+          isSigner: false;
         },
         {
-          "name": "vault",
-          "isMut": true,
-          "isSigner": false
+          name: 'vault';
+          isMut: true;
+          isSigner: false;
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
+          name: 'systemProgram';
+          isMut: false;
+          isSigner: false;
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
+          name: 'tokenProgram';
+          isMut: false;
+          isSigner: false;
         },
         {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
+          name: 'rent';
+          isMut: false;
+          isSigner: false;
         }
-      ],
-      "args": [
+      ];
+      args: [
         {
-          "name": "quantityToAdd",
-          "type": "u64"
+          name: 'quantityToAdd';
+          type: 'u64';
         }
-      ]
+      ];
     },
     {
-      "name": "buy",
-      "accounts": [
+      name: 'buy';
+      accounts: [
         {
-          "name": "buyer",
-          "isMut": false,
-          "isSigner": true
+          name: 'buyer';
+          isMut: false;
+          isSigner: true;
         },
         {
-          "name": "buyerNftTokenAccount",
-          "isMut": true,
-          "isSigner": false
+          name: 'buyerNftTokenAccount';
+          isMut: true;
+          isSigner: false;
         },
         {
-          "name": "buyerPayingTokenAccount",
-          "isMut": true,
-          "isSigner": false
+          name: 'buyerPayingTokenAccount';
+          isMut: true;
+          isSigner: false;
         },
         {
-          "name": "comptoir",
-          "isMut": false,
-          "isSigner": false
+          name: 'comptoir';
+          isMut: false;
+          isSigner: false;
         },
         {
-          "name": "comptoirDestAccount",
-          "isMut": true,
-          "isSigner": false
+          name: 'comptoirDestAccount';
+          isMut: true;
+          isSigner: false;
         },
         {
-          "name": "collection",
-          "isMut": false,
-          "isSigner": false
+          name: 'collection';
+          isMut: false;
+          isSigner: false;
         },
         {
-          "name": "metadata",
-          "isMut": false,
-          "isSigner": false
+          name: 'metadata';
+          isMut: false;
+          isSigner: false;
         },
         {
-          "name": "vault",
-          "isMut": true,
-          "isSigner": false
+          name: 'vault';
+          isMut: true;
+          isSigner: false;
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
+          name: 'systemProgram';
+          isMut: false;
+          isSigner: false;
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
+          name: 'tokenProgram';
+          isMut: false;
+          isSigner: false;
         }
-      ],
-      "args": [
+      ];
+      args: [
         {
-          "name": "askQuantity",
-          "type": "u64"
+          name: 'askQuantity';
+          type: 'u64';
         }
-      ]
+      ];
     },
     {
-      "name": "createBuyOffer",
-      "accounts": [
+      name: 'createBuyOffer';
+      accounts: [
         {
-          "name": "payer",
-          "isMut": true,
-          "isSigner": true
+          name: 'payer';
+          isMut: true;
+          isSigner: true;
         },
         {
-          "name": "nftMint",
-          "isMut": false,
-          "isSigner": false
+          name: 'nftMint';
+          isMut: false;
+          isSigner: false;
         },
         {
-          "name": "metadata",
-          "isMut": false,
-          "isSigner": false
+          name: 'metadata';
+          isMut: false;
+          isSigner: false;
         },
         {
-          "name": "comptoir",
-          "isMut": false,
-          "isSigner": false
+          name: 'comptoir';
+          isMut: false;
+          isSigner: false;
         },
         {
-          "name": "collection",
-          "isMut": true,
-          "isSigner": false
+          name: 'collection';
+          isMut: true;
+          isSigner: false;
         },
         {
-          "name": "escrow",
-          "isMut": true,
-          "isSigner": false
+          name: 'escrow';
+          isMut: true;
+          isSigner: false;
         },
         {
-          "name": "buyerPayingAccount",
-          "isMut": true,
-          "isSigner": false
+          name: 'buyerPayingAccount';
+          isMut: true;
+          isSigner: false;
         },
         {
-          "name": "buyerNftAccount",
-          "isMut": true,
-          "isSigner": false
+          name: 'buyerNftAccount';
+          isMut: true;
+          isSigner: false;
         },
         {
-          "name": "buyOffer",
-          "isMut": true,
-          "isSigner": false
+          name: 'buyOffer';
+          isMut: true;
+          isSigner: false;
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
+          name: 'systemProgram';
+          isMut: false;
+          isSigner: false;
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
+          name: 'tokenProgram';
+          isMut: false;
+          isSigner: false;
         },
         {
-          "name": "associatedTokenProgram",
-          "isMut": false,
-          "isSigner": false
+          name: 'associatedTokenProgram';
+          isMut: false;
+          isSigner: false;
         },
         {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
+          name: 'rent';
+          isMut: false;
+          isSigner: false;
         }
-      ],
-      "args": [
+      ];
+      args: [
         {
-          "name": "priceProposition",
-          "type": "u64"
+          name: 'priceProposition';
+          type: 'u64';
         }
-      ]
+      ];
     },
     {
-      "name": "removeBuyOffer",
-      "accounts": [
+      name: 'removeBuyOffer';
+      accounts: [
         {
-          "name": "buyer",
-          "isMut": true,
-          "isSigner": true
+          name: 'buyer';
+          isMut: true;
+          isSigner: true;
         },
         {
-          "name": "buyerPayingAccount",
-          "isMut": true,
-          "isSigner": false
+          name: 'buyerPayingAccount';
+          isMut: true;
+          isSigner: false;
         },
         {
-          "name": "comptoir",
-          "isMut": false,
-          "isSigner": false
+          name: 'comptoir';
+          isMut: false;
+          isSigner: false;
         },
         {
-          "name": "escrow",
-          "isMut": true,
-          "isSigner": false
+          name: 'escrow';
+          isMut: true;
+          isSigner: false;
         },
         {
-          "name": "buyOffer",
-          "isMut": true,
-          "isSigner": false
+          name: 'buyOffer';
+          isMut: true;
+          isSigner: false;
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
+          name: 'systemProgram';
+          isMut: false;
+          isSigner: false;
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
+          name: 'tokenProgram';
+          isMut: false;
+          isSigner: false;
         },
         {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
+          name: 'rent';
+          isMut: false;
+          isSigner: false;
         }
-      ],
-      "args": []
+      ];
+      args: [];
     },
     {
-      "name": "executeOffer",
-      "accounts": [
+      name: 'executeOffer';
+      accounts: [
         {
-          "name": "seller",
-          "isMut": false,
-          "isSigner": true
+          name: 'seller';
+          isMut: false;
+          isSigner: true;
         },
         {
-          "name": "buyer",
-          "isMut": true,
-          "isSigner": false
+          name: 'buyer';
+          isMut: true;
+          isSigner: false;
         },
         {
-          "name": "comptoir",
-          "isMut": false,
-          "isSigner": false
+          name: 'comptoir';
+          isMut: false;
+          isSigner: false;
         },
         {
-          "name": "collection",
-          "isMut": true,
-          "isSigner": false
+          name: 'collection';
+          isMut: true;
+          isSigner: false;
         },
         {
-          "name": "comptoirDestAccount",
-          "isMut": true,
-          "isSigner": false
+          name: 'comptoirDestAccount';
+          isMut: true;
+          isSigner: false;
         },
         {
-          "name": "escrow",
-          "isMut": true,
-          "isSigner": false
+          name: 'escrow';
+          isMut: true;
+          isSigner: false;
         },
         {
-          "name": "sellerFundsDestAccount",
-          "isMut": true,
-          "isSigner": false
+          name: 'sellerFundsDestAccount';
+          isMut: true;
+          isSigner: false;
         },
         {
-          "name": "destination",
-          "isMut": true,
-          "isSigner": false
+          name: 'destination';
+          isMut: true;
+          isSigner: false;
         },
         {
-          "name": "sellerNftAccount",
-          "isMut": true,
-          "isSigner": false
+          name: 'sellerNftAccount';
+          isMut: true;
+          isSigner: false;
         },
         {
-          "name": "metadata",
-          "isMut": false,
-          "isSigner": false
+          name: 'metadata';
+          isMut: false;
+          isSigner: false;
         },
         {
-          "name": "buyOffer",
-          "isMut": true,
-          "isSigner": false
+          name: 'buyOffer';
+          isMut: true;
+          isSigner: false;
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
+          name: 'systemProgram';
+          isMut: false;
+          isSigner: false;
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
+          name: 'tokenProgram';
+          isMut: false;
+          isSigner: false;
         },
         {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
+          name: 'rent';
+          isMut: false;
+          isSigner: false;
         }
-      ],
-      "args": []
+      ];
+      args: [];
     }
-  ],
-  "accounts": [
+  ];
+  accounts: [
     {
-      "name": "comptoir",
-      "type": {
-        "kind": "struct",
-        "fields": [
+      name: 'comptoir';
+      type: {
+        kind: 'struct';
+        fields: [
           {
-            "name": "fees",
-            "type": "u16"
+            name: 'fees';
+            type: 'u16';
           },
           {
-            "name": "feesDestination",
-            "type": "publicKey"
+            name: 'feesDestination';
+            type: 'publicKey';
           },
           {
-            "name": "authority",
-            "type": "publicKey"
+            name: 'authority';
+            type: 'publicKey';
           },
           {
-            "name": "mint",
-            "type": "publicKey"
+            name: 'mint';
+            type: 'publicKey';
           }
-        ]
-      }
+        ];
+      };
     },
     {
-      "name": "sellOrder",
-      "type": {
-        "kind": "struct",
-        "fields": [
+      name: 'sellOrder';
+      type: {
+        kind: 'struct';
+        fields: [
           {
-            "name": "comptoir",
-            "type": "publicKey"
+            name: 'comptoir';
+            type: 'publicKey';
           },
           {
-            "name": "price",
-            "type": "u64"
+            name: 'price';
+            type: 'u64';
           },
           {
-            "name": "quantity",
-            "type": "u64"
+            name: 'quantity';
+            type: 'u64';
           },
           {
-            "name": "mint",
-            "type": "publicKey"
+            name: 'mint';
+            type: 'publicKey';
           },
           {
-            "name": "authority",
-            "type": "publicKey"
+            name: 'authority';
+            type: 'publicKey';
           },
           {
-            "name": "destination",
-            "type": "publicKey"
+            name: 'destination';
+            type: 'publicKey';
           }
-        ]
-      }
+        ];
+      };
     },
     {
-      "name": "collection",
-      "type": {
-        "kind": "struct",
-        "fields": [
+      name: 'collection';
+      type: {
+        kind: 'struct';
+        fields: [
           {
-            "name": "comptoirKey",
-            "type": "publicKey"
+            name: 'comptoirKey';
+            type: 'publicKey';
           },
           {
-            "name": "symbol",
-            "type": "string"
+            name: 'symbol';
+            type: 'string';
           },
           {
-            "name": "requiredVerifier",
-            "type": "publicKey"
+            name: 'requiredVerifier';
+            type: 'publicKey';
           },
           {
-            "name": "fees",
-            "type": {
-              "option": "u16"
-            }
+            name: 'fees';
+            type: {
+              option: 'u16';
+            };
           },
           {
-            "name": "ignoreCreatorFee",
-            "type": "bool"
+            name: 'ignoreCreatorFee';
+            type: 'bool';
           }
-        ]
-      }
+        ];
+      };
     },
     {
-      "name": "buyOffer",
-      "type": {
-        "kind": "struct",
-        "fields": [
+      name: 'buyOffer';
+      type: {
+        kind: 'struct';
+        fields: [
           {
-            "name": "comptoir",
-            "type": "publicKey"
+            name: 'comptoir';
+            type: 'publicKey';
           },
           {
-            "name": "mint",
-            "type": "publicKey"
+            name: 'mint';
+            type: 'publicKey';
           },
           {
-            "name": "proposedPrice",
-            "type": "u64"
+            name: 'proposedPrice';
+            type: 'u64';
           },
           {
-            "name": "authority",
-            "type": "publicKey"
+            name: 'authority';
+            type: 'publicKey';
           },
           {
-            "name": "destination",
-            "type": "publicKey"
+            name: 'destination';
+            type: 'publicKey';
           }
-        ]
-      }
+        ];
+      };
     }
-  ],
-  "events": [
+  ];
+  events: [
     {
-      "name": "BoughtSellOrderEvent",
-      "fields": [
+      name: 'BoughtSellOrderEvent';
+      fields: [
         {
-          "name": "sellOrder",
-          "type": "publicKey",
-          "index": false
+          name: 'sellOrder';
+          type: 'publicKey';
+          index: false;
         },
         {
-          "name": "quantity",
-          "type": "u64",
-          "index": false
+          name: 'quantity';
+          type: 'u64';
+          index: false;
         },
         {
-          "name": "buyer",
-          "type": "publicKey",
-          "index": false
+          name: 'buyer';
+          type: 'publicKey';
+          index: false;
         }
-      ]
+      ];
     }
-  ],
-  "errors": [
+  ];
+  errors: [
     {
-      "code": 6000,
-      "name": "ErrFeeShouldLowerOrEqualThan10000",
-      "msg": "Fee should be <= 10000"
+      code: 6000;
+      name: 'ErrFeeShouldLowerOrEqualThan10000';
+      msg: 'Fee should be <= 10000';
     },
     {
-      "code": 6001,
-      "name": "ErrTryingToUnlistMoreThanOwned",
-      "msg": "Trying to unlist more than owned"
+      code: 6001;
+      name: 'ErrTryingToUnlistMoreThanOwned';
+      msg: 'Trying to unlist more than owned';
     },
     {
-      "code": 6002,
-      "name": "ErrCouldNotBuyEnoughItem",
-      "msg": "Could not buy the required quantity of items"
+      code: 6002;
+      name: 'ErrCouldNotBuyEnoughItem';
+      msg: 'Could not buy the required quantity of items';
     },
     {
-      "code": 6003,
-      "name": "ErrMetaDataMintDoesNotMatchItemMint",
-      "msg": "metadata mint does not match item mint"
+      code: 6003;
+      name: 'ErrMetaDataMintDoesNotMatchItemMint';
+      msg: 'metadata mint does not match item mint';
     },
     {
-      "code": 6004,
-      "name": "ErrNftNotPartOfCollection",
-      "msg": "nft not part of collection"
+      code: 6004;
+      name: 'ErrNftNotPartOfCollection';
+      msg: 'nft not part of collection';
     },
     {
-      "code": 6005,
-      "name": "DerivedKeyInvalid",
-      "msg": "Derived key invalid"
+      code: 6005;
+      name: 'DerivedKeyInvalid';
+      msg: 'Derived key invalid';
     },
     {
-      "code": 6006,
-      "name": "NotInitialized",
-      "msg": "AccountNotInitialized"
+      code: 6006;
+      name: 'NotInitialized';
+      msg: 'AccountNotInitialized';
     }
-  ]
+  ];
 };
 
 export const IDL: Comptoir = {
-  "version": "0.1.0",
-  "name": "comptoir",
-  "instructions": [
+  version: '0.1.0',
+  name: 'comptoir',
+  instructions: [
     {
-      "name": "createComptoir",
-      "accounts": [
+      name: 'createComptoir',
+      accounts: [
         {
-          "name": "payer",
-          "isMut": true,
-          "isSigner": true
+          name: 'payer',
+          isMut: true,
+          isSigner: true,
         },
         {
-          "name": "comptoir",
-          "isMut": true,
-          "isSigner": false
+          name: 'comptoir',
+          isMut: true,
+          isSigner: false,
         },
         {
-          "name": "mint",
-          "isMut": false,
-          "isSigner": false
+          name: 'mint',
+          isMut: false,
+          isSigner: false,
         },
         {
-          "name": "escrow",
-          "isMut": true,
-          "isSigner": false
+          name: 'escrow',
+          isMut: true,
+          isSigner: false,
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
+          name: 'systemProgram',
+          isMut: false,
+          isSigner: false,
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
+          name: 'tokenProgram',
+          isMut: false,
+          isSigner: false,
         },
         {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        }
+          name: 'rent',
+          isMut: false,
+          isSigner: false,
+        },
       ],
-      "args": [
+      args: [
         {
-          "name": "mint",
-          "type": "publicKey"
+          name: 'mint',
+          type: 'publicKey',
         },
         {
-          "name": "fees",
-          "type": "u16"
+          name: 'fees',
+          type: 'u16',
         },
         {
-          "name": "feesDestination",
-          "type": "publicKey"
+          name: 'feesDestination',
+          type: 'publicKey',
         },
         {
-          "name": "authority",
-          "type": "publicKey"
-        }
-      ]
+          name: 'authority',
+          type: 'publicKey',
+        },
+      ],
     },
     {
-      "name": "updateComptoir",
-      "accounts": [
+      name: 'updateComptoir',
+      accounts: [
         {
-          "name": "authority",
-          "isMut": false,
-          "isSigner": true
+          name: 'authority',
+          isMut: false,
+          isSigner: true,
         },
         {
-          "name": "comptoir",
-          "isMut": true,
-          "isSigner": false
-        }
+          name: 'comptoir',
+          isMut: true,
+          isSigner: false,
+        },
       ],
-      "args": [
+      args: [
         {
-          "name": "optionalFees",
-          "type": {
-            "option": "u16"
-          }
+          name: 'optionalFees',
+          type: {
+            option: 'u16',
+          },
         },
         {
-          "name": "optionalFeesDestination",
-          "type": {
-            "option": "publicKey"
-          }
+          name: 'optionalFeesDestination',
+          type: {
+            option: 'publicKey',
+          },
         },
         {
-          "name": "optionalAuthority",
-          "type": {
-            "option": "publicKey"
-          }
-        }
-      ]
+          name: 'optionalAuthority',
+          type: {
+            option: 'publicKey',
+          },
+        },
+      ],
     },
     {
-      "name": "updateComptoirMint",
-      "accounts": [
+      name: 'updateComptoirMint',
+      accounts: [
         {
-          "name": "authority",
-          "isMut": true,
-          "isSigner": true
+          name: 'authority',
+          isMut: true,
+          isSigner: true,
         },
         {
-          "name": "comptoir",
-          "isMut": true,
-          "isSigner": false
+          name: 'comptoir',
+          isMut: true,
+          isSigner: false,
         },
         {
-          "name": "mint",
-          "isMut": false,
-          "isSigner": false
+          name: 'mint',
+          isMut: false,
+          isSigner: false,
         },
         {
-          "name": "escrow",
-          "isMut": true,
-          "isSigner": false
+          name: 'escrow',
+          isMut: true,
+          isSigner: false,
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
+          name: 'systemProgram',
+          isMut: false,
+          isSigner: false,
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
+          name: 'tokenProgram',
+          isMut: false,
+          isSigner: false,
         },
         {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        }
+          name: 'rent',
+          isMut: false,
+          isSigner: false,
+        },
       ],
-      "args": [
+      args: [
         {
-          "name": "mint",
-          "type": "publicKey"
+          name: 'mint',
+          type: 'publicKey',
         },
         {
-          "name": "feesDestination",
-          "type": "publicKey"
-        }
-      ]
+          name: 'feesDestination',
+          type: 'publicKey',
+        },
+      ],
     },
     {
-      "name": "createCollection",
-      "accounts": [
+      name: 'createCollection',
+      accounts: [
         {
-          "name": "authority",
-          "isMut": true,
-          "isSigner": true
+          name: 'authority',
+          isMut: true,
+          isSigner: true,
         },
         {
-          "name": "comptoir",
-          "isMut": true,
-          "isSigner": false
+          name: 'comptoir',
+          isMut: true,
+          isSigner: false,
         },
         {
-          "name": "collection",
-          "isMut": true,
-          "isSigner": false
+          name: 'collection',
+          isMut: true,
+          isSigner: false,
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
+          name: 'systemProgram',
+          isMut: false,
+          isSigner: false,
         },
         {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        }
+          name: 'rent',
+          isMut: false,
+          isSigner: false,
+        },
       ],
-      "args": [
+      args: [
         {
-          "name": "symbol",
-          "type": "string"
+          name: 'symbol',
+          type: 'string',
         },
         {
-          "name": "requiredVerifier",
-          "type": "publicKey"
+          name: 'requiredVerifier',
+          type: 'publicKey',
         },
         {
-          "name": "fee",
-          "type": {
-            "option": "u16"
-          }
+          name: 'fee',
+          type: {
+            option: 'u16',
+          },
         },
         {
-          "name": "ignoreFee",
-          "type": "bool"
-        }
-      ]
+          name: 'ignoreFee',
+          type: 'bool',
+        },
+      ],
     },
     {
-      "name": "updateCollection",
-      "accounts": [
+      name: 'updateCollection',
+      accounts: [
         {
-          "name": "authority",
-          "isMut": false,
-          "isSigner": true
+          name: 'authority',
+          isMut: false,
+          isSigner: true,
         },
         {
-          "name": "comptoir",
-          "isMut": false,
-          "isSigner": false
+          name: 'comptoir',
+          isMut: false,
+          isSigner: false,
         },
         {
-          "name": "collection",
-          "isMut": true,
-          "isSigner": false
-        }
+          name: 'collection',
+          isMut: true,
+          isSigner: false,
+        },
       ],
-      "args": [
+      args: [
         {
-          "name": "optionalFee",
-          "type": {
-            "option": "u16"
-          }
+          name: 'optionalFee',
+          type: {
+            option: 'u16',
+          },
         },
         {
-          "name": "optionalSymbol",
-          "type": {
-            "option": "string"
-          }
+          name: 'optionalSymbol',
+          type: {
+            option: 'string',
+          },
         },
         {
-          "name": "optionalRequiredVerifier",
-          "type": {
-            "option": "publicKey"
-          }
+          name: 'optionalRequiredVerifier',
+          type: {
+            option: 'publicKey',
+          },
         },
         {
-          "name": "optionalIgnoreCreatorFee",
-          "type": {
-            "option": "bool"
-          }
-        }
-      ]
+          name: 'optionalIgnoreCreatorFee',
+          type: {
+            option: 'bool',
+          },
+        },
+      ],
     },
     {
-      "name": "createSellOrder",
-      "accounts": [
+      name: 'createSellOrder',
+      accounts: [
         {
-          "name": "payer",
-          "isMut": true,
-          "isSigner": true
+          name: 'payer',
+          isMut: true,
+          isSigner: true,
         },
         {
-          "name": "sellerNftTokenAccount",
-          "isMut": true,
-          "isSigner": false
+          name: 'sellerNftTokenAccount',
+          isMut: true,
+          isSigner: false,
         },
         {
-          "name": "comptoir",
-          "isMut": false,
-          "isSigner": false
+          name: 'comptoir',
+          isMut: false,
+          isSigner: false,
         },
         {
-          "name": "collection",
-          "isMut": false,
-          "isSigner": false
+          name: 'collection',
+          isMut: false,
+          isSigner: false,
         },
         {
-          "name": "mint",
-          "isMut": false,
-          "isSigner": false
+          name: 'mint',
+          isMut: false,
+          isSigner: false,
         },
         {
-          "name": "metadata",
-          "isMut": false,
-          "isSigner": false
+          name: 'metadata',
+          isMut: false,
+          isSigner: false,
         },
         {
-          "name": "vault",
-          "isMut": true,
-          "isSigner": false
+          name: 'vault',
+          isMut: true,
+          isSigner: false,
         },
         {
-          "name": "sellOrder",
-          "isMut": true,
-          "isSigner": false
+          name: 'sellOrder',
+          isMut: true,
+          isSigner: false,
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
+          name: 'systemProgram',
+          isMut: false,
+          isSigner: false,
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
+          name: 'tokenProgram',
+          isMut: false,
+          isSigner: false,
         },
         {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        }
+          name: 'rent',
+          isMut: false,
+          isSigner: false,
+        },
       ],
-      "args": [
+      args: [
         {
-          "name": "price",
-          "type": "u64"
+          name: 'price',
+          type: 'u64',
         },
         {
-          "name": "quantity",
-          "type": "u64"
+          name: 'quantity',
+          type: 'u64',
         },
         {
-          "name": "destination",
-          "type": "publicKey"
-        }
-      ]
+          name: 'destination',
+          type: 'publicKey',
+        },
+      ],
     },
     {
-      "name": "removeSellOrder",
-      "accounts": [
+      name: 'removeSellOrder',
+      accounts: [
         {
-          "name": "authority",
-          "isMut": true,
-          "isSigner": true
+          name: 'authority',
+          isMut: true,
+          isSigner: true,
         },
         {
-          "name": "sellerNftTokenAccount",
-          "isMut": true,
-          "isSigner": false
+          name: 'sellerNftTokenAccount',
+          isMut: true,
+          isSigner: false,
         },
         {
-          "name": "sellOrder",
-          "isMut": true,
-          "isSigner": false
+          name: 'sellOrder',
+          isMut: true,
+          isSigner: false,
         },
         {
-          "name": "vault",
-          "isMut": true,
-          "isSigner": false
+          name: 'vault',
+          isMut: true,
+          isSigner: false,
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
+          name: 'systemProgram',
+          isMut: false,
+          isSigner: false,
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
+          name: 'tokenProgram',
+          isMut: false,
+          isSigner: false,
         },
         {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        }
+          name: 'rent',
+          isMut: false,
+          isSigner: false,
+        },
       ],
-      "args": [
+      args: [
         {
-          "name": "quantityToUnlist",
-          "type": "u64"
-        }
-      ]
+          name: 'quantityToUnlist',
+          type: 'u64',
+        },
+      ],
     },
     {
-      "name": "addQuantityToSellOrder",
-      "accounts": [
+      name: 'addQuantityToSellOrder',
+      accounts: [
         {
-          "name": "authority",
-          "isMut": true,
-          "isSigner": true
+          name: 'authority',
+          isMut: true,
+          isSigner: true,
         },
         {
-          "name": "sellerNftTokenAccount",
-          "isMut": true,
-          "isSigner": false
+          name: 'sellerNftTokenAccount',
+          isMut: true,
+          isSigner: false,
         },
         {
-          "name": "sellOrder",
-          "isMut": true,
-          "isSigner": false
+          name: 'sellOrder',
+          isMut: true,
+          isSigner: false,
         },
         {
-          "name": "vault",
-          "isMut": true,
-          "isSigner": false
+          name: 'vault',
+          isMut: true,
+          isSigner: false,
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
+          name: 'systemProgram',
+          isMut: false,
+          isSigner: false,
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
+          name: 'tokenProgram',
+          isMut: false,
+          isSigner: false,
         },
         {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        }
+          name: 'rent',
+          isMut: false,
+          isSigner: false,
+        },
       ],
-      "args": [
+      args: [
         {
-          "name": "quantityToAdd",
-          "type": "u64"
-        }
-      ]
+          name: 'quantityToAdd',
+          type: 'u64',
+        },
+      ],
     },
     {
-      "name": "buy",
-      "accounts": [
+      name: 'buy',
+      accounts: [
         {
-          "name": "buyer",
-          "isMut": false,
-          "isSigner": true
+          name: 'buyer',
+          isMut: false,
+          isSigner: true,
         },
         {
-          "name": "buyerNftTokenAccount",
-          "isMut": true,
-          "isSigner": false
+          name: 'buyerNftTokenAccount',
+          isMut: true,
+          isSigner: false,
         },
         {
-          "name": "buyerPayingTokenAccount",
-          "isMut": true,
-          "isSigner": false
+          name: 'buyerPayingTokenAccount',
+          isMut: true,
+          isSigner: false,
         },
         {
-          "name": "comptoir",
-          "isMut": false,
-          "isSigner": false
+          name: 'comptoir',
+          isMut: false,
+          isSigner: false,
         },
         {
-          "name": "comptoirDestAccount",
-          "isMut": true,
-          "isSigner": false
+          name: 'comptoirDestAccount',
+          isMut: true,
+          isSigner: false,
         },
         {
-          "name": "collection",
-          "isMut": false,
-          "isSigner": false
+          name: 'collection',
+          isMut: false,
+          isSigner: false,
         },
         {
-          "name": "metadata",
-          "isMut": false,
-          "isSigner": false
+          name: 'metadata',
+          isMut: false,
+          isSigner: false,
         },
         {
-          "name": "vault",
-          "isMut": true,
-          "isSigner": false
+          name: 'vault',
+          isMut: true,
+          isSigner: false,
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
+          name: 'systemProgram',
+          isMut: false,
+          isSigner: false,
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        }
+          name: 'tokenProgram',
+          isMut: false,
+          isSigner: false,
+        },
       ],
-      "args": [
+      args: [
         {
-          "name": "askQuantity",
-          "type": "u64"
-        }
-      ]
+          name: 'askQuantity',
+          type: 'u64',
+        },
+      ],
     },
     {
-      "name": "createBuyOffer",
-      "accounts": [
+      name: 'createBuyOffer',
+      accounts: [
         {
-          "name": "payer",
-          "isMut": true,
-          "isSigner": true
+          name: 'payer',
+          isMut: true,
+          isSigner: true,
         },
         {
-          "name": "nftMint",
-          "isMut": false,
-          "isSigner": false
+          name: 'nftMint',
+          isMut: false,
+          isSigner: false,
         },
         {
-          "name": "metadata",
-          "isMut": false,
-          "isSigner": false
+          name: 'metadata',
+          isMut: false,
+          isSigner: false,
         },
         {
-          "name": "comptoir",
-          "isMut": false,
-          "isSigner": false
+          name: 'comptoir',
+          isMut: false,
+          isSigner: false,
         },
         {
-          "name": "collection",
-          "isMut": true,
-          "isSigner": false
+          name: 'collection',
+          isMut: true,
+          isSigner: false,
         },
         {
-          "name": "escrow",
-          "isMut": true,
-          "isSigner": false
+          name: 'escrow',
+          isMut: true,
+          isSigner: false,
         },
         {
-          "name": "buyerPayingAccount",
-          "isMut": true,
-          "isSigner": false
+          name: 'buyerPayingAccount',
+          isMut: true,
+          isSigner: false,
         },
         {
-          "name": "buyerNftAccount",
-          "isMut": true,
-          "isSigner": false
+          name: 'buyerNftAccount',
+          isMut: true,
+          isSigner: false,
         },
         {
-          "name": "buyOffer",
-          "isMut": true,
-          "isSigner": false
+          name: 'buyOffer',
+          isMut: true,
+          isSigner: false,
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
+          name: 'systemProgram',
+          isMut: false,
+          isSigner: false,
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
+          name: 'tokenProgram',
+          isMut: false,
+          isSigner: false,
         },
         {
-          "name": "associatedTokenProgram",
-          "isMut": false,
-          "isSigner": false
+          name: 'associatedTokenProgram',
+          isMut: false,
+          isSigner: false,
         },
         {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        }
+          name: 'rent',
+          isMut: false,
+          isSigner: false,
+        },
       ],
-      "args": [
+      args: [
         {
-          "name": "priceProposition",
-          "type": "u64"
-        }
-      ]
+          name: 'priceProposition',
+          type: 'u64',
+        },
+      ],
     },
     {
-      "name": "removeBuyOffer",
-      "accounts": [
+      name: 'removeBuyOffer',
+      accounts: [
         {
-          "name": "buyer",
-          "isMut": true,
-          "isSigner": true
+          name: 'buyer',
+          isMut: true,
+          isSigner: true,
         },
         {
-          "name": "buyerPayingAccount",
-          "isMut": true,
-          "isSigner": false
+          name: 'buyerPayingAccount',
+          isMut: true,
+          isSigner: false,
         },
         {
-          "name": "comptoir",
-          "isMut": false,
-          "isSigner": false
+          name: 'comptoir',
+          isMut: false,
+          isSigner: false,
         },
         {
-          "name": "escrow",
-          "isMut": true,
-          "isSigner": false
+          name: 'escrow',
+          isMut: true,
+          isSigner: false,
         },
         {
-          "name": "buyOffer",
-          "isMut": true,
-          "isSigner": false
+          name: 'buyOffer',
+          isMut: true,
+          isSigner: false,
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
+          name: 'systemProgram',
+          isMut: false,
+          isSigner: false,
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
+          name: 'tokenProgram',
+          isMut: false,
+          isSigner: false,
         },
         {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        }
+          name: 'rent',
+          isMut: false,
+          isSigner: false,
+        },
       ],
-      "args": []
+      args: [],
     },
     {
-      "name": "executeOffer",
-      "accounts": [
+      name: 'executeOffer',
+      accounts: [
         {
-          "name": "seller",
-          "isMut": false,
-          "isSigner": true
+          name: 'seller',
+          isMut: false,
+          isSigner: true,
         },
         {
-          "name": "buyer",
-          "isMut": true,
-          "isSigner": false
+          name: 'buyer',
+          isMut: true,
+          isSigner: false,
         },
         {
-          "name": "comptoir",
-          "isMut": false,
-          "isSigner": false
+          name: 'comptoir',
+          isMut: false,
+          isSigner: false,
         },
         {
-          "name": "collection",
-          "isMut": true,
-          "isSigner": false
+          name: 'collection',
+          isMut: true,
+          isSigner: false,
         },
         {
-          "name": "comptoirDestAccount",
-          "isMut": true,
-          "isSigner": false
+          name: 'comptoirDestAccount',
+          isMut: true,
+          isSigner: false,
         },
         {
-          "name": "escrow",
-          "isMut": true,
-          "isSigner": false
+          name: 'escrow',
+          isMut: true,
+          isSigner: false,
         },
         {
-          "name": "sellerFundsDestAccount",
-          "isMut": true,
-          "isSigner": false
+          name: 'sellerFundsDestAccount',
+          isMut: true,
+          isSigner: false,
         },
         {
-          "name": "destination",
-          "isMut": true,
-          "isSigner": false
+          name: 'destination',
+          isMut: true,
+          isSigner: false,
         },
         {
-          "name": "sellerNftAccount",
-          "isMut": true,
-          "isSigner": false
+          name: 'sellerNftAccount',
+          isMut: true,
+          isSigner: false,
         },
         {
-          "name": "metadata",
-          "isMut": false,
-          "isSigner": false
+          name: 'metadata',
+          isMut: false,
+          isSigner: false,
         },
         {
-          "name": "buyOffer",
-          "isMut": true,
-          "isSigner": false
+          name: 'buyOffer',
+          isMut: true,
+          isSigner: false,
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
+          name: 'systemProgram',
+          isMut: false,
+          isSigner: false,
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
+          name: 'tokenProgram',
+          isMut: false,
+          isSigner: false,
         },
         {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        }
+          name: 'rent',
+          isMut: false,
+          isSigner: false,
+        },
       ],
-      "args": []
-    }
+      args: [],
+    },
   ],
-  "accounts": [
+  accounts: [
     {
-      "name": "comptoir",
-      "type": {
-        "kind": "struct",
-        "fields": [
+      name: 'comptoir',
+      type: {
+        kind: 'struct',
+        fields: [
           {
-            "name": "fees",
-            "type": "u16"
+            name: 'fees',
+            type: 'u16',
           },
           {
-            "name": "feesDestination",
-            "type": "publicKey"
+            name: 'feesDestination',
+            type: 'publicKey',
           },
           {
-            "name": "authority",
-            "type": "publicKey"
+            name: 'authority',
+            type: 'publicKey',
           },
           {
-            "name": "mint",
-            "type": "publicKey"
-          }
-        ]
-      }
+            name: 'mint',
+            type: 'publicKey',
+          },
+        ],
+      },
     },
     {
-      "name": "sellOrder",
-      "type": {
-        "kind": "struct",
-        "fields": [
+      name: 'sellOrder',
+      type: {
+        kind: 'struct',
+        fields: [
           {
-            "name": "comptoir",
-            "type": "publicKey"
+            name: 'comptoir',
+            type: 'publicKey',
           },
           {
-            "name": "price",
-            "type": "u64"
+            name: 'price',
+            type: 'u64',
           },
           {
-            "name": "quantity",
-            "type": "u64"
+            name: 'quantity',
+            type: 'u64',
           },
           {
-            "name": "mint",
-            "type": "publicKey"
+            name: 'mint',
+            type: 'publicKey',
           },
           {
-            "name": "authority",
-            "type": "publicKey"
+            name: 'authority',
+            type: 'publicKey',
           },
           {
-            "name": "destination",
-            "type": "publicKey"
-          }
-        ]
-      }
+            name: 'destination',
+            type: 'publicKey',
+          },
+        ],
+      },
     },
     {
-      "name": "collection",
-      "type": {
-        "kind": "struct",
-        "fields": [
+      name: 'collection',
+      type: {
+        kind: 'struct',
+        fields: [
           {
-            "name": "comptoirKey",
-            "type": "publicKey"
+            name: 'comptoirKey',
+            type: 'publicKey',
           },
           {
-            "name": "symbol",
-            "type": "string"
+            name: 'symbol',
+            type: 'string',
           },
           {
-            "name": "requiredVerifier",
-            "type": "publicKey"
+            name: 'requiredVerifier',
+            type: 'publicKey',
           },
           {
-            "name": "fees",
-            "type": {
-              "option": "u16"
-            }
+            name: 'fees',
+            type: {
+              option: 'u16',
+            },
           },
           {
-            "name": "ignoreCreatorFee",
-            "type": "bool"
-          }
-        ]
-      }
+            name: 'ignoreCreatorFee',
+            type: 'bool',
+          },
+        ],
+      },
     },
     {
-      "name": "buyOffer",
-      "type": {
-        "kind": "struct",
-        "fields": [
+      name: 'buyOffer',
+      type: {
+        kind: 'struct',
+        fields: [
           {
-            "name": "comptoir",
-            "type": "publicKey"
+            name: 'comptoir',
+            type: 'publicKey',
           },
           {
-            "name": "mint",
-            "type": "publicKey"
+            name: 'mint',
+            type: 'publicKey',
           },
           {
-            "name": "proposedPrice",
-            "type": "u64"
+            name: 'proposedPrice',
+            type: 'u64',
           },
           {
-            "name": "authority",
-            "type": "publicKey"
+            name: 'authority',
+            type: 'publicKey',
           },
           {
-            "name": "destination",
-            "type": "publicKey"
-          }
-        ]
-      }
-    }
+            name: 'destination',
+            type: 'publicKey',
+          },
+        ],
+      },
+    },
   ],
-  "events": [
+  events: [
     {
-      "name": "BoughtSellOrderEvent",
-      "fields": [
+      name: 'BoughtSellOrderEvent',
+      fields: [
         {
-          "name": "sellOrder",
-          "type": "publicKey",
-          "index": false
+          name: 'sellOrder',
+          type: 'publicKey',
+          index: false,
         },
         {
-          "name": "quantity",
-          "type": "u64",
-          "index": false
+          name: 'quantity',
+          type: 'u64',
+          index: false,
         },
         {
-          "name": "buyer",
-          "type": "publicKey",
-          "index": false
-        }
-      ]
-    }
+          name: 'buyer',
+          type: 'publicKey',
+          index: false,
+        },
+      ],
+    },
   ],
-  "errors": [
+  errors: [
     {
-      "code": 6000,
-      "name": "ErrFeeShouldLowerOrEqualThan10000",
-      "msg": "Fee should be <= 10000"
+      code: 6000,
+      name: 'ErrFeeShouldLowerOrEqualThan10000',
+      msg: 'Fee should be <= 10000',
     },
     {
-      "code": 6001,
-      "name": "ErrTryingToUnlistMoreThanOwned",
-      "msg": "Trying to unlist more than owned"
+      code: 6001,
+      name: 'ErrTryingToUnlistMoreThanOwned',
+      msg: 'Trying to unlist more than owned',
     },
     {
-      "code": 6002,
-      "name": "ErrCouldNotBuyEnoughItem",
-      "msg": "Could not buy the required quantity of items"
+      code: 6002,
+      name: 'ErrCouldNotBuyEnoughItem',
+      msg: 'Could not buy the required quantity of items',
     },
     {
-      "code": 6003,
-      "name": "ErrMetaDataMintDoesNotMatchItemMint",
-      "msg": "metadata mint does not match item mint"
+      code: 6003,
+      name: 'ErrMetaDataMintDoesNotMatchItemMint',
+      msg: 'metadata mint does not match item mint',
     },
     {
-      "code": 6004,
-      "name": "ErrNftNotPartOfCollection",
-      "msg": "nft not part of collection"
+      code: 6004,
+      name: 'ErrNftNotPartOfCollection',
+      msg: 'nft not part of collection',
     },
     {
-      "code": 6005,
-      "name": "DerivedKeyInvalid",
-      "msg": "Derived key invalid"
+      code: 6005,
+      name: 'DerivedKeyInvalid',
+      msg: 'Derived key invalid',
     },
     {
-      "code": 6006,
-      "name": "NotInitialized",
-      "msg": "AccountNotInitialized"
-    }
-  ]
+      code: 6006,
+      name: 'NotInitialized',
+      msg: 'AccountNotInitialized',
+    },
+  ],
 };

--- a/js/yarn.lock
+++ b/js/yarn.lock
@@ -9,6 +9,18 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@cspotcode/source-map-consumer@0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz#33bf4b7b39c178821606f669bbc447a6a629786b"
+  integrity sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==
+
+"@cspotcode/source-map-support@0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz#4789840aa859e46d2f3173727ab707c66bf344f5"
+  integrity sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==
+  dependencies:
+    "@cspotcode/source-map-consumer" "0.8.0"
+
 "@ethersproject/bytes@^5.6.0":
   version "5.6.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.6.1.tgz#24f916e411f82a8a60412344bf4a813b917eefe7"
@@ -114,6 +126,26 @@
     superstruct "^0.14.2"
     tweetnacl "^1.0.0"
 
+"@tsconfig/node10@^1.0.7":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.8.tgz#c1e4e80d6f964fbecb3359c43bd48b40f7cadad9"
+  integrity sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==
+
+"@tsconfig/node12@^1.0.7":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.9.tgz#62c1f6dee2ebd9aead80dc3afa56810e58e1a04c"
+  integrity sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==
+
+"@tsconfig/node14@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.1.tgz#95f2d167ffb9b8d2068b0b235302fafd4df711f2"
+  integrity sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==
+
+"@tsconfig/node16@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.2.tgz#423c77877d0569db20e1fc80885ac4118314010e"
+  integrity sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==
+
 "@types/bn.js@^4.11.5":
   version "4.11.6"
   resolved "https://registry.yarnpkg.com/@types/bn.js/-/bn.js-4.11.6.tgz#c306c70d9358aaea33cd4eda092a742b9505967c"
@@ -183,6 +215,21 @@ JSONStream@^1.3.5:
   dependencies:
     jsonparse "^1.2.0"
     through ">=2.2.7 <3"
+
+acorn-walk@^8.1.1:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
+  integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
+
+acorn@^8.4.1:
+  version "8.7.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.0.tgz#90951fde0f8f09df93549481e5fc141445b791cf"
+  integrity sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==
+
+arg@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -299,16 +346,10 @@ commander@^2.20.3:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
-comptoirjs@^0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/comptoirjs/-/comptoirjs-0.0.1.tgz#018d1a606ba1c58d98ffa737029e21c8b05c50d7"
-  integrity sha512-HIxhfzLlEuNs5CZ/YM/l2GKIHiAhtmCe2NpONcgI6U9VeqXn/RzNy1LuFeReHB9Pk8iuIYRwmBZ1vPEFf5uHgQ==
-  dependencies:
-    "@metaplex/js" "^3.0.0"
-    "@project-serum/anchor" "^0.23.0"
-    "@solana/spl-token" "^0.1.8"
-    "@solana/web3.js" "^1.31.0"
-    typescript "^4.3.5"
+create-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
 cross-fetch@^3.1.4, cross-fetch@^3.1.5:
   version "3.1.5"
@@ -331,6 +372,11 @@ delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
+
+diff@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
+  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 dot-case@^3.0.4:
   version "3.0.4"
@@ -486,6 +532,11 @@ lower-case@^2.0.2:
   dependencies:
     tslib "^2.0.3"
 
+make-error@^1.1.1:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
+  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
+
 mime-db@1.52.0:
   version "1.52.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
@@ -609,6 +660,25 @@ traverse-chain@~0.1.0:
   resolved "https://registry.yarnpkg.com/traverse-chain/-/traverse-chain-0.1.0.tgz#61dbc2d53b69ff6091a12a168fd7d433107e40f1"
   integrity sha1-YdvC1Ttp/2CRoSoWj9fUMxB+QPE=
 
+ts-node@^10.7.0:
+  version "10.7.0"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.7.0.tgz#35d503d0fab3e2baa672a0e94f4b40653c2463f5"
+  integrity sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==
+  dependencies:
+    "@cspotcode/source-map-support" "0.7.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    v8-compile-cache-lib "^3.0.0"
+    yn "3.1.1"
+
 tslib@^2.0.3:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
@@ -619,7 +689,7 @@ tweetnacl@^1.0.0:
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-1.0.3.tgz#ac0af71680458d8a6378d0d0d050ab1407d35596"
   integrity sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==
 
-typescript@^4.3.5:
+typescript@^4.6.3:
   version "4.6.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.3.tgz#eefeafa6afdd31d725584c67a0eaba80f6fc6c6c"
   integrity sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==
@@ -635,6 +705,11 @@ uuid@^8.3.0, uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
+v8-compile-cache-lib@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.0.tgz#0582bcb1c74f3a2ee46487ceecf372e46bce53e8"
+  integrity sha512-mpSYqfsFvASnSn5qMiwrr4VKfumbPyONLCOPmsR3A6pTY/r0+tSaVbgPWSAIuzbk3lCTa+FForeTiO+wBQGkjA==
 
 webidl-conversions@^3.0.0:
   version "3.0.1"
@@ -653,3 +728,8 @@ ws@^7.4.5:
   version "7.5.7"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.7.tgz#9e0ac77ee50af70d58326ecff7e85eb3fa375e67"
   integrity sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==
+
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==


### PR DESCRIPTION
would be great if the essential modules were exported from root, otherwise:
```
import { Comptoir } from '@aurory/comptoirjs/comptoir'
import { Collection } from '@aurory/comptoirjs/collection'
import { COMPTOIR_PROGRAM_ID } from '@aurory/comptoirjs/constant'
import { Comptoir as ComptoirDefinition } from '@aurory/comptoirjs/types/comptoir'
```

instead of 
```
import { Comptoir, Collection, ComptoirDefinition, COMPTOIR_PROGRAM_ID } from '@aurory/comptoirjs'
```